### PR TITLE
using updated openmc-source-plotter api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@
 
 # for local testing I tend to use this build command
 # docker build -t neutronics-workshop --build-arg compile_cores=14 --build-arg build_double_down=ON .
+# and then run with this command
+# docker run -p 8888:8888 neutronics-workshop
 
 # This can't be done currently as the base images uses conda installs for moab / dagmc which don't compile with OpenMC
 FROM ghcr.io/openmc-data-storage/miniconda3_4.9.2_endfb-7.1_nndc_tendl_2019:latest as dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -261,8 +261,8 @@ RUN pip install neutronics_material_maker \
                 openmc-tally-unit-converter \
                 regular_mesh_plotter \
                 spectrum_plotter \
-                openmc_source_plotter \
                 dagmc_bounding_box \
+                openmc_source_plotter \
                 openmc_mesh_tally_to_vtk
 
 # an older version of openmc is need to provide an older executable

--- a/tasks/task_04_make_sources/1_point_source_plots.ipynb
+++ b/tasks/task_04_make_sources/1_point_source_plots.ipynb
@@ -13,33 +13,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/jshimwell/miniconda3/envs/openmc-dagmc/lib/python3.8/site-packages/IPython/core/display.py:724: UserWarning:\n",
-      "\n",
-      "Consider using IPython.display.IFrame instead\n",
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/j9dT1Viqcu4\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" allowfullscreen></iframe>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from IPython.display import HTML\n",
     "HTML('<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/j9dT1Viqcu4\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\" allowfullscreen></iframe>')"
@@ -68,16 +44,16 @@
    "outputs": [],
    "source": [
     "# initialises a new source object\n",
-    "source = openmc.Source()\n",
+    "my_source = openmc.Source()\n",
     "\n",
     "# sets the location of the source to x=0 y=0 z=0\n",
-    "source.space = openmc.stats.Point((0, 0, 0))\n",
+    "my_source.space = openmc.stats.Point((0, 0, 0))\n",
     "\n",
     "# sets the direction to isotropic\n",
-    "source.angle = openmc.stats.Isotropic()\n",
+    "my_source.angle = openmc.stats.Isotropic()\n",
     "\n",
     "# sets the energy distribution to 100% 14MeV neutrons\n",
-    "source.energy = openmc.stats.Discrete([14e6], [1])"
+    "my_source.energy = openmc.stats.Discrete([14e6], [1])"
    ]
   },
   {
@@ -95,8 +71,10 @@
    "source": [
     "import openmc_source_plotter as osp\n",
     "\n",
-    "osp.create_initial_particles(source, openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc')\n",
-    "osp.plot_energy_from_initial_source()"
+    "osp.plot_source_energy(\n",
+    "    source=my_source,\n",
+    "    openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc'\n",
+    ")"
    ]
   },
   {
@@ -112,16 +90,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "source = openmc.Source()\n",
-    "source.space = openmc.stats.Point((0, 0, 0))\n",
-    "source.angle = openmc.stats.Isotropic()\n",
+    "my_source_2 = openmc.Source()\n",
+    "my_source_2.space = openmc.stats.Point((0, 0, 0))\n",
+    "my_source_2.angle = openmc.stats.Isotropic()\n",
     "\n",
     "# Documentation on the Watt distribution is here\n",
     "# https://docs.openmc.org/en/stable/pythonapi/generated/openmc.data.WattEnergy.html\n",
     "source.energy = openmc.stats.Watt(a=988000.0, b=2.249e-06)\n",
     "\n",
-    "osp.create_initial_particles(source, openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc')\n",
-    "osp.plot_energy_from_initial_source()"
+    "osp.plot_source_energy(\n",
+    "    source=my_source_2,\n",
+    "    openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc'\n",
+    ")"
    ]
   },
   {
@@ -137,16 +117,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "source = openmc.Source()\n",
-    "source.space = openmc.stats.Point((0, 0, 0))\n",
-    "source.angle = openmc.stats.Isotropic()\n",
+    "my_source_3 = openmc.Source()\n",
+    "my_source_3.space = openmc.stats.Point((0, 0, 0))\n",
+    "my_source_3.angle = openmc.stats.Isotropic()\n",
     "\n",
     "# Documentation on the Muir distribution is here\n",
     "# https://docs.openmc.org/en/stable/pythonapi/generated/openmc.stats.Muir.html\n",
-    "source.energy = openmc.stats.Muir(e0=14080000.0, m_rat=5.0, kt=20000.0)\n",
+    "my_source_3.energy = openmc.stats.Muir(e0=14080000.0, m_rat=5.0, kt=20000.0)\n",
     "\n",
-    "osp.create_initial_particles(source, openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc')\n",
-    "osp.plot_energy_from_initial_source()"
+    "osp.plot_source_energy(\n",
+    "    source=my_source_3,\n",
+    "    openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc'\n",
+    ")"
    ]
   },
   {
@@ -163,13 +145,15 @@
    "outputs": [],
    "source": [
     "# Creates an isotropic point source with monoenergetic 14MeV neutrons\n",
-    "source = openmc.Source()\n",
-    "source.space = openmc.stats.Point((0, 0, 0))\n",
-    "source.angle = openmc.stats.Isotropic()\n",
-    "source.energy = openmc.stats.Discrete([14e6], [1])\n",
+    "my_source_4 = openmc.Source()\n",
+    "my_source_4.space = openmc.stats.Point((0, 0, 0))\n",
+    "my_source_4.angle = openmc.stats.Isotropic()\n",
+    "my_source_4.energy = openmc.stats.Discrete([14e6], [1])\n",
     "\n",
-    "osp.create_initial_particles(source, openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc')\n",
-    "osp.plot_position_from_initial_source()"
+    "osp.plot_source_position(\n",
+    "    source=my_source_4,\n",
+    "    openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc'\n",
+    ")"
    ]
   },
   {
@@ -186,13 +170,15 @@
    "outputs": [],
    "source": [
     "# Creates an isotropic point source with monoenergetic 14MeV neutrons\n",
-    "source = openmc.Source()\n",
-    "source.space = openmc.stats.Point((0, 0, 0))\n",
-    "source.angle = openmc.stats.Isotropic()\n",
-    "source.energy = openmc.stats.Discrete([14e6], [1])\n",
+    "my_source_5 = openmc.Source()\n",
+    "my_source_5.space = openmc.stats.Point((0, 0, 0))\n",
+    "my_source_5.angle = openmc.stats.Isotropic()\n",
+    "my_source_5.energy = openmc.stats.Discrete([14e6], [1])\n",
     "\n",
-    "osp.create_initial_particles(source, openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc')\n",
-    "osp.plot_direction_from_initial_source()"
+    "osp.plot_source_direction(\n",
+    "    source=my_source_5,\n",
+    "    openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc'\n",
+    ")"
    ]
   },
   {
@@ -229,7 +215,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,

--- a/tasks/task_04_make_sources/1_point_source_plots.ipynb
+++ b/tasks/task_04_make_sources/1_point_source_plots.ipynb
@@ -96,7 +96,7 @@
     "\n",
     "# Documentation on the Watt distribution is here\n",
     "# https://docs.openmc.org/en/stable/pythonapi/generated/openmc.data.WattEnergy.html\n",
-    "source.energy = openmc.stats.Watt(a=988000.0, b=2.249e-06)\n",
+    "my_source_2.energy = openmc.stats.Watt(a=988000.0, b=2.249e-06)\n",
     "\n",
     "osp.plot_source_energy(\n",
     "    source=my_source_2,\n",
@@ -215,7 +215,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/tasks/task_04_make_sources/2_ring_source.ipynb
+++ b/tasks/task_04_make_sources/2_ring_source.ipynb
@@ -44,7 +44,7 @@
     "import openmc\n",
     "\n",
     "# initialises a new source object\n",
-    "source = openmc.Source()\n",
+    "my_source = openmc.Source()\n",
     "\n",
     "# the distribution of radius is just a single value\n",
     "radius = openmc.stats.Discrete([10], [1])\n",
@@ -56,13 +56,13 @@
     "angle = openmc.stats.Uniform(a=0., b=2* 3.14159265359)\n",
     "\n",
     "# this makes the ring source using the three distributions and a radius\n",
-    "source.space = openmc.stats.CylindricalIndependent(r=radius, phi=angle, z=z_values, origin=(0.0, 0.0, 0.0))\n",
+    "my_source.space = openmc.stats.CylindricalIndependent(r=radius, phi=angle, z=z_values, origin=(0.0, 0.0, 0.0))\n",
     "\n",
     "# sets the direction to isotropic\n",
-    "source.angle = openmc.stats.Isotropic()\n",
+    "my_source.angle = openmc.stats.Isotropic()\n",
     "\n",
     "# sets the energy distribution to a Muir distribution neutrons\n",
-    "source.energy = openmc.stats.Muir(e0=14080000.0, m_rat=5.0, kt=20000.0)"
+    "my_source.energy = openmc.stats.Muir(e0=14080000.0, m_rat=5.0, kt=20000.0)"
    ]
   },
   {
@@ -80,8 +80,10 @@
    "source": [
     "import openmc_source_plotter as osp\n",
     "\n",
-    "osp.create_initial_particles(source, openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc')\n",
-    "osp.plot_position_from_initial_source()"
+    "osp.plot_source_position(\n",
+    "    source=my_source,\n",
+    "    openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc'\n",
+    ")"
    ]
   },
   {
@@ -116,7 +118,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,

--- a/tasks/task_04_make_sources/2_ring_source.ipynb
+++ b/tasks/task_04_make_sources/2_ring_source.ipynb
@@ -118,7 +118,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/tasks/task_04_make_sources/3_plasma_source_plots.ipynb
+++ b/tasks/task_04_make_sources/3_plasma_source_plots.ipynb
@@ -74,8 +74,10 @@
    "source": [
     "import openmc_source_plotter as osp\n",
     "\n",
-    "osp.create_initial_particles(my_source, openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc')\n",
-    "osp.plot_energy_from_initial_source()"
+    "osp.plot_source_energy(\n",
+    "    source=my_source,\n",
+    "    openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc'\n",
+    ")"
    ]
   },
   {
@@ -91,7 +93,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "osp.plot_position_from_initial_source()"
+    "osp.plot_source_position(\n",
+    "    source=my_source,\n",
+    "    openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc'\n",
+    ")"
    ]
   },
   {
@@ -107,7 +112,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "osp.plot_direction_from_initial_source()"
+    "osp.plot_source_direction(\n",
+    "    source=my_source,\n",
+    "    openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc'\n",
+    ")"
    ]
   },
   {
@@ -136,7 +144,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,

--- a/tasks/task_04_make_sources/3_plasma_source_plots.ipynb
+++ b/tasks/task_04_make_sources/3_plasma_source_plots.ipynb
@@ -144,7 +144,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/tasks/task_04_make_sources/4_neutron_tracks.ipynb
+++ b/tasks/task_04_make_sources/4_neutron_tracks.ipynb
@@ -204,7 +204,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/tasks/task_04_make_sources/5_gamma_source_example.ipynb
+++ b/tasks/task_04_make_sources/5_gamma_source_example.ipynb
@@ -84,11 +84,12 @@
    "outputs": [],
    "source": [
     "import openmc_source_plotter as osp\n",
+    "import numpy as np\n",
     "\n",
     "# number_of_particles can be increased to sample more particles\n",
     "osp.plot_source_energy(\n",
     "    source=my_source,\n",
-    "    number_of_particles=1000\n",
+    "    number_of_particles=1000,\n",
     "    openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc',\n",
     "    energy_bins=np.linspace(0, 2e6, 50)\n",
     ")\n",
@@ -130,7 +131,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.11"
+   "version": "3.9.5"
   }
  },
  "nbformat": 4,

--- a/tasks/task_04_make_sources/5_gamma_source_example.ipynb
+++ b/tasks/task_04_make_sources/5_gamma_source_example.ipynb
@@ -15,7 +15,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -54,18 +54,18 @@
    "outputs": [],
    "source": [
     "# initialises a new source object\n",
-    "source = openmc.Source()\n",
+    "my_source = openmc.Source()\n",
     "\n",
     "# sets the location of the source to x=0 y=0 z=0\n",
-    "source.space = openmc.stats.Point((0, 0, 0))\n",
+    "my_source.space = openmc.stats.Point((0, 0, 0))\n",
     "\n",
     "# sets the direction to isotropic\n",
-    "source.angle = openmc.stats.Isotropic()\n",
+    "my_source.angle = openmc.stats.Isotropic()\n",
     "\n",
     "# sets the energy distribution to 50% 1.1MeV photons and 50% 1.3MeV photons\n",
-    "source.energy = openmc.stats.Discrete([1.1732e6,1.3325e6], [0.5, 0.5])\n",
+    "my_source.energy = openmc.stats.Discrete([1.1732e6,1.3325e6], [0.5, 0.5])\n",
     "\n",
-    "source.particle = 'photon'"
+    "my_source.particle = 'photon'"
    ]
   },
   {
@@ -86,9 +86,14 @@
     "import openmc_source_plotter as osp\n",
     "\n",
     "# number_of_particles can be increased to sample more particles\n",
-    "osp.create_initial_particles(source, number_of_particles=1000, openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc')\n",
-    "# this time we are setting the number of energy bins for the plot\n",
-    "osp.plot_energy_from_initial_source(energy_bins=np.linspace(0, 2e6, 50))"
+    "osp.plot_source_energy(\n",
+    "    source=my_source,\n",
+    "    number_of_particles=1000\n",
+    "    openmc_exec='/opt/conda/envs/openmc_version_0_11_0/bin/openmc',\n",
+    "    energy_bins=np.linspace(0, 2e6, 50)\n",
+    ")\n",
+    "\n",
+    "# this time we are setting the number of energy bins for the plot\n"
    ]
   },
   {
@@ -125,7 +130,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The openmc-source-plotter was recently updated to version 0.1 and API has a few changes.

This PR keeps the workshop working with the latest openmc-source-plotter