### PR TITLE
adding cubic interpolation for dose

### DIFF
--- a/tasks/task_09_CSG_surface_tally_dose/1_surface_dose_from_gamma_source.ipynb
+++ b/tasks/task_09_CSG_surface_tally_dose/1_surface_dose_from_gamma_source.ipynb
@@ -226,9 +226,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Dose coeffients can then be used in a neutronics tally with the openmc.EnergyFunctionFilter.\n",
+    "Dose coefficients can then be used in a neutronics tally with the openmc.EnergyFunctionFilter.\n",
     "\n",
-    "This will effectivly multilpy the particle energy spectra with the effictive dose coefficient to produce a single number for effective dose."
+    "This will multiply the particle energy spectra with the effective dose coefficient to produce a single number for effective dose.\n",
+    "\n",
+    "ICRP recommend the use of 'cubic' interpolation.\n",
+    "\"For interpolations of absorbed dose and effective dose per fluence, a four-point (cubic) Lagrangian interpolation formula is recommended, and alog–log graph scale is more appropriate. Interpolations of absorbed dose and effective dose per air kerma of photons should be carried out using a four-point(cubic) Lagrangian interpolation formula, and a linear–log graph scale is more appropriate.\" \n",
+    "https://journals.sagepub.com/doi/pdf/10.1177/ANIB_40_2-5"
    ]
   },
   {
@@ -238,7 +242,10 @@
    "outputs": [],
    "source": [
     "energy_function_filter_n = openmc.EnergyFunctionFilter(energy_bins_n, dose_coeffs_n)\n",
+    "energy_function_filter_n.interpolation == 'cubic'\n",
+    "\n",
     "energy_function_filter_p = openmc.EnergyFunctionFilter(energy_bins_p, dose_coeffs_p)\n",
+    "energy_function_filter_p.interpolation == 'cubic'\n",
     "\n",
     "photon_particle_filter = openmc.ParticleFilter([\"photon\"])\n",
     "surface_filter = openmc.SurfaceFilter(sphere_1)\n",


### PR DESCRIPTION
A nice new feature for openmc allows cubit interpolation for the energyfilter

Once [this](https://github.com/openmc-dev/openmc/issues/1671) PR is merged in we can update the dose example in this repo