### PR TITLE
added instant RR example

### DIFF
--- a/tasks/task_14_activation_transmutation_depletion/0_simple_transmutation_reaction_rate_simulation.py
+++ b/tasks/task_14_activation_transmutation_depletion/0_simple_transmutation_reaction_rate_simulation.py
@@ -1,3 +1,6 @@
+# This example finds the transmutation rates in a material.
+# This is an introduction task for the topic and for real inventory tracking
+# decay and material evolution would need to be considered.
 
 import re
 

--- a/tasks/task_14_activation_transmutation_depletion/0_simple_transmutation_reaction_rate_simulation.py
+++ b/tasks/task_14_activation_transmutation_depletion/0_simple_transmutation_reaction_rate_simulation.py
@@ -1,0 +1,86 @@
+
+import re
+
+import openmc
+from openmc.data import ATOMIC_NUMBER, ATOMIC_SYMBOL
+from openmc.deplete.chain import REACTIONS
+
+# creates a material
+material = openmc.Material()
+material.add_element('Fe', 1)
+material.set_density('g/cm3', 7.7)
+materials = openmc.Materials([material])
+
+# creates a geometry
+surface = openmc.Sphere(r=500, boundary_type='vacuum')
+cell = openmc.Cell(region=-surface)
+cell.fill = material
+geometry = openmc.Geometry([cell])
+
+# creates simulation settings
+settings = openmc.Settings()
+settings.batches = 10
+settings.inactive = 0
+settings.particles = 500
+settings.run_mode = 'fixed source'
+
+# Create a DT point source
+my_source = openmc.IndependentSource()
+my_source.energy = openmc.stats.Discrete([14e6], [1])
+settings.source = my_source
+
+# gets all the possible reactions like (n,2n), (n,p), (n,2a) etc
+reactions = list(REACTIONS.keys())
+
+# makes a tally for every nuclide in the material and every reaction
+rr_tally = openmc.Tally(name='RR')
+rr_tally.nuclides = material.get_nuclides()
+rr_tally.scores = reactions
+tallies = openmc.Tallies([rr_tally])
+
+# builds the model and runs it
+model = openmc.model.Model(geometry, materials, settings, tallies)
+sp_filename = model.run()
+
+# gets the simulation results
+sp = openmc.StatePoint(sp_filename)
+
+# gets the tally
+tbr_tally = sp.get_tally(name='RR')
+
+# converts to a pandas dataframe for easy manipulation
+df = tbr_tally.get_pandas_dataframe()
+# sorts the reactions from highest to lowest
+df = df.sort_values('mean', ascending=False)
+
+# this loop goes through the reactions getting the reaction rate (mean) for each
+# nuclide (nuclide) and each reaction (score)
+print('Reaction rates per source neutron')
+for index, row in df.iterrows():
+    if row['mean']!= 0.:
+        score = row['score']
+        nuclide = row['nuclide']
+
+        # gets the reaction change in terms of delta atomic number (dA)
+        # and delta mass number (dZ). This is a tuple for example (n,2n) is
+        # (-1, 0) because the atomic number decrease by one and the mass number
+        # stays the same
+        dAdZ = REACTIONS[score].dadz
+
+        # gets the element symbol from the nuclide name for example Fe from Fe56
+        element_symbol = re.split('(\d+)', nuclide)[0]
+        # gets the Z number from the nuclide name for example 56 from Fe56
+        Z_number = int(re.split('(\d+)', nuclide)[1])
+
+        # looks up the atomic number from the element symbol
+        A_number = ATOMIC_NUMBER[element_symbol]
+
+        # increases the atomic and mass numbers according to the delta values
+        new_Z = Z_number + dAdZ[1]
+        new_A = A_number + dAdZ[0]
+
+        # gets the element symbol of the potentially new element
+        new_element_symbol = ATOMIC_SYMBOL[new_A]
+
+        # prints all the transmutations and the reaction rates
+        print(f"{element_symbol}{Z_number} -> {score} -> {new_element_symbol}{new_Z} per source neutron {row['mean']}")

--- a/tasks/task_14_activation_transmutation_depletion/0_simple_transmutation_reaction_rate_simulation.py
+++ b/tasks/task_14_activation_transmutation_depletion/0_simple_transmutation_reaction_rate_simulation.py
@@ -10,12 +10,12 @@ from openmc.deplete.chain import REACTIONS
 
 # creates a material
 material = openmc.Material()
-material.add_element('Fe', 1)
-material.set_density('g/cm3', 7.7)
+material.add_element("Fe", 1)
+material.set_density("g/cm3", 7.7)
 materials = openmc.Materials([material])
 
 # creates a geometry
-surface = openmc.Sphere(r=500, boundary_type='vacuum')
+surface = openmc.Sphere(r=500, boundary_type="vacuum")
 cell = openmc.Cell(region=-surface)
 cell.fill = material
 geometry = openmc.Geometry([cell])
@@ -25,7 +25,7 @@ settings = openmc.Settings()
 settings.batches = 10
 settings.inactive = 0
 settings.particles = 500
-settings.run_mode = 'fixed source'
+settings.run_mode = "fixed source"
 
 # Create a DT point source
 my_source = openmc.IndependentSource()
@@ -36,7 +36,7 @@ settings.source = my_source
 reactions = list(REACTIONS.keys())
 
 # makes a tally for every nuclide in the material and every reaction
-rr_tally = openmc.Tally(name='RR')
+rr_tally = openmc.Tally(name="RR")
 rr_tally.nuclides = material.get_nuclides()
 rr_tally.scores = reactions
 tallies = openmc.Tallies([rr_tally])
@@ -49,20 +49,20 @@ sp_filename = model.run()
 sp = openmc.StatePoint(sp_filename)
 
 # gets the tally
-tbr_tally = sp.get_tally(name='RR')
+tbr_tally = sp.get_tally(name="RR")
 
 # converts to a pandas dataframe for easy manipulation
 df = tbr_tally.get_pandas_dataframe()
 # sorts the reactions from highest to lowest
-df = df.sort_values('mean', ascending=False)
+df = df.sort_values("mean", ascending=False)
 
 # this loop goes through the reactions getting the reaction rate (mean) for each
 # nuclide (nuclide) and each reaction (score)
-print('Reaction rates per source neutron')
+print("Reaction rates per source neutron")
 for index, row in df.iterrows():
-    if row['mean']!= 0.:
-        score = row['score']
-        nuclide = row['nuclide']
+    if row["mean"] != 0.0:
+        score = row["score"]
+        nuclide = row["nuclide"]
 
         # gets the reaction change in terms of delta atomic number (dA)
         # and delta mass number (dZ). This is a tuple for example (n,2n) is
@@ -71,19 +71,26 @@ for index, row in df.iterrows():
         dAdZ = REACTIONS[score].dadz
 
         # gets the element symbol from the nuclide name for example Fe from Fe56
-        element_symbol = re.split('(\d+)', nuclide)[0]
+        element_symbol = re.split("(\d+)", nuclide)[0]
         # gets the Z number from the nuclide name for example 56 from Fe56
-        Z_number = int(re.split('(\d+)', nuclide)[1])
+        neutron_plus_proton_number = int(re.split("(\d+)", nuclide)[1])
 
         # looks up the atomic number from the element symbol
-        A_number = ATOMIC_NUMBER[element_symbol]
+        proton_number = ATOMIC_NUMBER[element_symbol]
 
         # increases the atomic and mass numbers according to the delta values
-        new_Z = Z_number + dAdZ[1]
-        new_A = A_number + dAdZ[0]
+        new_proton_number = proton_number + dAdZ[1]
+
+        new_neutron_plus_proton_number = neutron_plus_proton_number + dAdZ[0]
+        secondaries = REACTIONS[score].secondaries
+        secondaries_str = ""
+        if len(secondaries) > 0:
+            secondaries_str = f"+{'+'.join(secondaries)}"
 
         # gets the element symbol of the potentially new element
-        new_element_symbol = ATOMIC_SYMBOL[new_A]
+        new_element_symbol = ATOMIC_SYMBOL[new_proton_number]
 
         # prints all the transmutations and the reaction rates
-        print(f"{element_symbol}{Z_number} -> {score} -> {new_element_symbol}{new_Z} per source neutron {row['mean']}")
+        print(
+            f"{element_symbol}{neutron_plus_proton_number} -> {score} -> {new_element_symbol}{new_neutron_plus_proton_number}{secondaries_str} per source neutron {row['mean']}"
+        )


### PR DESCRIPTION
adds a simple example that prints the reaction rates out.

Ignores decay but perhaps a good starting point for the 

this simulation outputs

```python
Reaction rates per source neutron
Fe56 -> (n,gamma) -> Co56 per source neutron 1.025854612757616
Fe56 -> (n,2n) -> Mn56 per source neutron 0.2716360793926368
Fe56 -> (n,p) -> Fe55 per source neutron 0.08312525494874211
Fe54 -> (n,gamma) -> Co54 per source neutron 0.07801311651291538
Fe57 -> (n,gamma) -> Co57 per source neutron 0.0460413382551078
Fe54 -> (n,p) -> Fe53 per source neutron 0.02243182676385541
Fe57 -> (n,2n) -> Mn57 per source neutron 0.01565283708128125
Fe58 -> (n,gamma) -> Co58 per source neutron 0.005390444626596165
Fe56 -> (n,a) -> V54 per source neutron 0.0033066040882703
Fe58 -> (n,2n) -> Mn58 per source neutron 0.0017483418869545786
Fe57 -> (n,p) -> Fe56 per source neutron 0.0008784582563911659
Fe54 -> (n,a) -> V52 per source neutron 0.0003460461877476479
Fe54 -> (n,2p) -> Mn52 per source neutron 0.00016252846234054438
Fe57 -> (n,a) -> V55 per source neutron 8.290775390828133e-05
Fe58 -> (n,p) -> Fe57 per source neutron 6.80221038686676e-05
Fe54 -> (n,2n) -> Mn54 per source neutron 3.9134672794544226e-05
Fe58 -> (n,a) -> V56 per source neutron 3.996490521856659e-06
Fe56 -> (n,2p) -> Mn54 per source neutron 3.1003496627992295e-11
Fe57 -> (n,2p) -> Mn55 per source neutron 3.053267403678274e-13
```