### PR TITLE
Adding ocp 7.7.1 to docker

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,12 +28,5 @@ FROM base as jupyter_cmd
 
 ENV PORT 8888
 
-# ENV PYTHONPATH="/MOAB/moab/pymoab"
-# RUN pip install gmsh
-# RUN apt-get install libxcursor-dev -y
-# RUN apt-get install libxinerama-dev -y
-
-# libXinerama.so.1: cannot open shared object file: No such file or directory
-
 # could switch to --ip='*'
 CMD ["jupyter", "lab", "--notebook-dir=/tasks", "--port=8888", "--no-browser", "--ip=0.0.0.0", "--allow-root"]

--- a/.devcontainer/base.Dockerfile
+++ b/.devcontainer/base.Dockerfile
@@ -109,9 +109,6 @@ RUN pip install neutronics_material_maker[density] \
                 openmc_plot \
                 dagmc_geometry_slice_plotter
 
-RUN pip install git+https://github.com/fusion-energy/openmc_weight_window_generator.git
-
-
 # Python libraries used in the workshop
 RUN pip install cmake\
 # new version of cmake needed for openmc compile

--- a/.devcontainer/base.Dockerfile
+++ b/.devcontainer/base.Dockerfile
@@ -83,7 +83,6 @@ RUN apt-get --yes install libeigen3-dev \
                           libxinerama-dev 
                     
 RUN apt-get --yes install python3-pip python3-venv
-RUN pip install --upgrade pip
 
 
 # Enabling a venv within Docker is needed to avoid system wide installs
@@ -92,6 +91,7 @@ ENV VIRTUAL_ENV=/opt/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+RUN pip install --upgrade pip
 
 # python packages from the neutronics workflow
 RUN pip install neutronics_material_maker[density] \
@@ -113,14 +113,7 @@ RUN pip install neutronics_material_maker[density] \
 RUN pip install git+https://github.com/fusion-energy/openmc-plasma-source
 
 RUN pip install git+https://github.com/CadQuery/cadquery.git@bc82cb04c59668a1369d9ce648361c8786bbd1c8 --no-deps
-RUN pip install cadquery-ocp==7.7.1
-RUN pip install ezdxf
-RUN pip install multimethod>=1.7<2.0
-RUN pip install nlopt
-RUN pip install nptyping==2.0.1
-RUN pip install typish
-RUN pip install casadi
-RUN pip install path
+RUN pip install cadquery-ocp==7.7.1 "multimethod>=1.7<2.0" nlopt typish casadi path ezdxf nptyping==2.0.1
 
 # Python libraries used in the workshop
 RUN pip install cmake\
@@ -176,6 +169,7 @@ RUN if [ "$build_double_down" = "ON" ] ; \
 RUN mkdir MOAB && \
     cd MOAB && \
     # newer versions of moab (5.4.0, 5.4.1) don't produce an importable pymoab package!
+    # TODO try moab 5.5.0
     git clone  --single-branch --branch 5.3.1 --depth 1 https://bitbucket.org/fathomteam/moab.git && \
     mkdir build && \
     cd build && \
@@ -186,11 +180,11 @@ RUN mkdir MOAB && \
                   -DBUILD_SHARED_LIBS=ON \
                   -DENABLE_PYMOAB=ON \
                   -DCMAKE_INSTALL_PREFIX=/MOAB && \
-    mkdir -p MOAB/lib/pymoab/lib/python3.9/site-packages && \
-    PYTHONPATH=/MOAB/lib/pymoab/lib/python3.9/site-packages:${PYTHONPATH} make -j && \
-    PYTHONPATH=/MOAB/lib/pymoab/lib/python3.9/site-packages:${PYTHONPATH} make install -j
+    mkdir -p MOAB/lib/pymoab/lib/python3.11/site-packages && \
+    PYTHONPATH=/MOAB/lib/pymoab/lib/python3.11/site-packages:${PYTHONPATH} make -j && \
+    PYTHONPATH=/MOAB/lib/pymoab/lib/python3.11/site-packages:${PYTHONPATH} make install -j
 
-ENV PYTHONPATH="/MOAB/lib/python3.9/site-packages/pymoab-5.3.1-py3.9-linux-x86_64.egg/"
+ENV PYTHONPATH="/MOAB/lib/python3.11/site-packages/pymoab-5.3.1-py3.11-linux-x86_64.egg/"
 
 RUN python -c "import pymoab"
 

--- a/.devcontainer/base.Dockerfile
+++ b/.devcontainer/base.Dockerfile
@@ -83,8 +83,8 @@ RUN apt-get --yes install libeigen3-dev \
 # RUN conda install -c conda-forge mamba -y
 # RUN conda install -c fusion-energy -c cadquery -c conda-forge paramak==0.8.7 -y
 # RUN conda install -c fusion-energy -c cadquery -c conda-forge paramak==0.8.7 -y
-RUN pip install git+https://github.com/CadQuery/cadquery.git@bc82cb04c59668a1369d9ce648361c8786bbd1c8  \
-                paramak
+# RUN pip install git+https://github.com/CadQuery/cadquery.git@bc82cb04c59668a1369d9ce648361c8786bbd1c8 --no-deps
+# RUN pip install paramak
 
 RUN pip install gmsh
 # needed for gmsh
@@ -253,3 +253,15 @@ RUN wget https://github.com/mit-crpg/WMP_Library/releases/download/v1.1/WMP_Libr
 
 ENV OPENMC_CROSS_SECTIONS=/nuclear_data/cross_sections.xml
 ENV OPENMC_CHAIN_FILE=/nuclear_data/chain-endf-b8.0.xml
+
+RUN pip install git+https://github.com/CadQuery/cadquery.git@bc82cb04c59668a1369d9ce648361c8786bbd1c8 --no-deps
+RUN pip install paramak
+
+# have to build ocp from source as we need OCP version 7.7.1 which as the _address option
+RUN git clone https://github.com/CadQuery/OCP.git
+RUN git clone https://github.com/CadQuery/pywrap.git
+RUN cd pywrap && python -m pip install .
+RUN sudo apt-get install clang -y 
+RUN cd OCP && pywrap all ocp.toml
+RUN cd OCP && cmake -S OCP -B build
+RUN cd OCP && cmake --build build

--- a/.devcontainer/base.Dockerfile
+++ b/.devcontainer/base.Dockerfile
@@ -31,7 +31,7 @@
 # docker run -it neutronics-workshop:base
 
 # FROM mcr.microsoft.com/vscode/devcontainers/miniconda:0-3 as dependencies
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.9-bullseye as dependencies
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.10-bullseye as dependencies
 
 RUN apt-get --allow-releaseinfo-change update
 RUN apt-get --yes update && apt-get --yes upgrade
@@ -256,12 +256,14 @@ ENV OPENMC_CHAIN_FILE=/nuclear_data/chain-endf-b8.0.xml
 
 RUN pip install git+https://github.com/CadQuery/cadquery.git@bc82cb04c59668a1369d9ce648361c8786bbd1c8 --no-deps
 RUN pip install paramak
-
-# have to build ocp from source as we need OCP version 7.7.1 which as the _address option
-RUN git clone https://github.com/CadQuery/OCP.git
-RUN git clone https://github.com/CadQuery/pywrap.git
-RUN cd pywrap && python -m pip install .
-RUN sudo apt-get install clang -y 
-RUN cd OCP && pywrap all ocp.toml
-RUN cd OCP && cmake -S OCP -B build
-RUN cd OCP && cmake --build build
+# cadquery-ocp==7.7.1 needs python 3.10 or higher
+RUN pip install cadquery-ocp==7.7.1
+# # have to build ocp from source as we need OCP version 7.7.1 which as the _address option
+# RUN git clone https://github.com/CadQuery/OCP.git
+# RUN git clone https://github.com/CadQuery/pywrap.git
+# # RUN sudo apt-get install clang -y 
+# RUN pip install clang
+# RUN cd pywrap && python -m pip install .
+# RUN cd OCP && pywrap all ocp.toml
+# RUN cd OCP && cmake -S OCP -B build
+# RUN cd OCP && cmake --build build

--- a/.devcontainer/base.Dockerfile
+++ b/.devcontainer/base.Dockerfile
@@ -137,10 +137,6 @@ ARG include_avx=false
 ARG build_double_down=OFF
 
 # Clone and install Embree
-# embree from conda is not supported yet
-# TODO check if embree3 package on conda is supported
-# conda install -c conda-forge embree >> version: 2.17.7
-# requested version "3.6.1"
 # added following two lines to allow use on AMD CPUs see discussion
 # https://openmc.discourse.group/t/dagmc-geometry-open-mc-aborted-unexpectedly/1369/24?u=pshriwise  
 RUN if [ "$build_double_down" = "ON" ] ; \
@@ -184,10 +180,8 @@ ENV PYTHONPATH="/MOAB/lib/python3.9/site-packages/pymoab-5.3.1-py3.9-linux-x86_6
 
 RUN python -c "import pymoab"
 
-
 ENV PATH=$PATH:/MOAB/bin
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/MOAB/lib
-
 
 # Clone and install Double-Down
 RUN if [ "$build_double_down" = "ON" ] ; \
@@ -202,7 +196,6 @@ RUN if [ "$build_double_down" = "ON" ] ; \
         make -j"$compile_cores" install ; \
         rm -rf /double-down/build /double-down/double-down ; \
     fi
-
 
 # DAGMC version develop install from source
 RUN mkdir DAGMC && \
@@ -253,14 +246,6 @@ ENV OPENMC_CHAIN_FILE=/nuclear_data/chain-endf-b8.0.xml
 
 RUN pip install git+https://github.com/CadQuery/cadquery.git@bc82cb04c59668a1369d9ce648361c8786bbd1c8 --no-deps
 RUN pip install paramak
+
 # cadquery-ocp==7.7.1 needs python 3.10 or higher
 RUN pip install cadquery-ocp==7.7.1
-# # have to build ocp from source as we need OCP version 7.7.1 which as the _address option
-# RUN git clone https://github.com/CadQuery/OCP.git
-# RUN git clone https://github.com/CadQuery/pywrap.git
-# # RUN sudo apt-get install clang -y 
-# RUN pip install clang
-# RUN cd pywrap && python -m pip install .
-# RUN cd OCP && pywrap all ocp.toml
-# RUN cd OCP && cmake -S OCP -B build
-# RUN cd OCP && cmake --build build


### PR DESCRIPTION
this PR updates the docker image so that it can accommodate ocp version 7.7.1 which is needed by cad-to-dagmc