### PR TITLE
added max splits

### DIFF
--- a/tasks/task_13_variance_reduction/2_shielded_room_single_ww.ipynb
+++ b/tasks/task_13_variance_reduction/2_shielded_room_single_ww.ipynb
@@ -410,7 +410,7 @@
     "wwg = openmc.WeightWindowGenerator(\n",
     "    mesh=mesh,  # this is the mesh that covers the geometry\n",
     "    energy_bounds=np.linspace(0.0, 2.5e6, 10),  # 10 energy bins from 0 to max source energy\n",
-    "    particle_type='neutron'\n",
+    "    particle_type='neutron',\n",
     ")\n",
     "\n",
     "# The simulation with Weight Windows takes more time per particle because particles are splitting\n",
@@ -418,6 +418,7 @@
     "# we are reducing the number of particles so this simulation takes a similar amount of time\n",
     "# to the previous simulation that didn't use weight windows. So we can make a fair comparison\n",
     "model.settings.particles = 4900\n",
+    "model.settings.max_splits = 1_000  # controls the maximum partile splits over the entire lifetime of the particle\n",
     "model.settings.weight_window_generators = wwg"
    ]
   },
@@ -444,9 +445,9 @@
     "\n",
     "t1 = time.time()\n",
     "\n",
-    "print(f'total time without weight windows {int(t1-t0)}s')\n",
+    "print(f'total time with weight windows {int(t1-t0)}s')\n",
     "\n",
-    "plot_mesh_tally(ww_statepoint_filename, 'no_ww.png')"
+    "plot_mesh_tally(ww_statepoint_filename, 'ww.png')"
    ]
   },
   {
@@ -467,7 +468,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53fa1fce-f1b4-40b5-aa8f-fa58de32f65b",
+   "id": "09d8d704-75e5-4339-9ff0-da64ae79721c",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -489,7 +490,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/tasks/task_13_variance_reduction/3_sphere_iterative_per_run_ww.ipynb
+++ b/tasks/task_13_variance_reduction/3_sphere_iterative_per_run_ww.ipynb
@@ -142,7 +142,7 @@
     "# all (100%) of source particles are 14MeV energy\n",
     "energy = openmc.stats.Discrete([14e6], [1.0])\n",
     "\n",
-    "source = openmc.Source(space=space, angle=angle, energy=energy)\n",
+    "source = openmc.IndependentSource(space=space, angle=angle, energy=energy)\n",
     "source.particle = \"neutron\""
    ]
   },
@@ -162,7 +162,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mesh = openmc.RegularMesh().from_domain(domain=my_geometry)\n",
+    "mesh = openmc.RegularMesh().from_domain(domain=my_geometry, dimension=[20,20,20])\n",
     "\n",
     "mesh_filter = openmc.MeshFilter(mesh)\n",
     "\n",
@@ -199,6 +199,7 @@
     "my_settings.source = source\n",
     "my_settings.particles = 120\n",
     "my_settings.batches = 10\n",
+    "my_settings.max_splits = 4000  # controls the total number of maximum splits a particle can do over the entire lifetime\n",
     "\n",
     "# no need to write the tallies.out file which saves space and time when large meshes are used\n",
     "my_settings.output = {'tallies': False}"
@@ -329,7 +330,7 @@
     "    # wws.survival_ratio\n",
     "    # wws.max_lower_bound_ratio\n",
     "    # wws.weight_cutoff\n",
-    "    # wws.max_splits\n",
+    "    # wws.max_split  # controls the total number of maximum splits a particle can do per mesh voxel\n",
     "\n",
     "    # 5 iterations of weight window improvements\n",
     "    for i in range(5):\n",
@@ -355,20 +356,6 @@
     "            f'plot_{i}.png'\n",
     "        )"
    ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "e293ce43",
-   "metadata": {},
-   "source": []
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "79ec2340",
-   "metadata": {},
-   "source": []
   },
   {
    "attachments": {},
@@ -444,7 +431,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,

--- a/tasks/task_13_variance_reduction/4_sphere_iterative_per_batch_ww.ipynb
+++ b/tasks/task_13_variance_reduction/4_sphere_iterative_per_batch_ww.ipynb
@@ -156,6 +156,8 @@
     "my_settings.source = source\n",
     "my_settings.particles = 50000\n",
     "my_settings.batches = 5\n",
+    "my_settings.max_splits = 100  # controls the total number of maximum splits a particle can do over the entire lifetime\n",
+    "\n",
     "# the mesh tallies produce large tallies.out files so this output setting avoids writing the tallies.out and saves time\n",
     "my_settings.output = {'tallies': False}"
    ]
@@ -326,7 +328,7 @@
     "    # wws.survival_ratio\n",
     "    # wws.max_lower_bound_ratio\n",
     "    # wws.weight_cutoff\n",
-    "    # wws.max_splits\n",
+    "    # wws.max_split\n",
     "    \n",
     "    # gets a live pointer to the spectra tally that we will plot with each batch\n",
     "    spectra_tally = openmc.lib.tallies[outer_surface_spectra_tally.id]\n",
@@ -399,7 +401,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.9.16"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
when using weight windows one should probably set the openmc.settings.max_splits to a larger number to allow lots of particle splitting. Many thanks to Steve B for pointing this out