### PR TITLE
removing need for os.system call in example

### DIFF
--- a/tasks/task_11_CSG_shut_down_dose_tallies/2_faster_mulitiple_puse_shut_down_dose_rate_example.py
+++ b/tasks/task_11_CSG_shut_down_dose_tallies/2_faster_mulitiple_puse_shut_down_dose_rate_example.py
@@ -142,12 +142,7 @@ integrator = openmc.deplete.PredictorIntegrator(
 
 # this runs the depletion calculations for the timesteps
 # this does the neutron activation simulations and produces a depletion_results.h5 file
-integrator.integrate()
-# TODO add output dir to integrate command so we don't have to move the file like this
-# integrator.integrate(path=statepoints_folder / "neutrons" / "depletion_results.h5")
-# PR on openmc is open
-import os
-os.system(f'mv depletion_results.h5 {statepoints_folder / "neutrons" / "depletion_results.h5"}')
+integrator.integrate(path=statepoints_folder / "neutrons" / "depletion_results.h5")
 
 # Now we have done the neutron activation simulations we can start the work needed for the decay gamma simulations.
 


### PR DESCRIPTION
Thanks to a recent update in openmc we can now specify a path when calling integrate()