### PR TITLE
Fix broken link to Task 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ There is a [slide](https://fusion-energy.github.io/neutronics-workshop-slides/in
 There is also a [Gather Town](https://gather.town/app/QnHxhg6bPf8KQdii/openmc-workshop) space which is great for working through the workshop with colleagues.
 
 These examples require specific versions of software packages and nuclear data to run correctly.
-Therefore **I highly recommend making use of the containerised environment** to run these example notebooks.
+Therefore **I highly recommend making use of the containerized environment** to run these example notebooks.
 
 The repository has benefited greatly from user feedback. Please feel free to
-raise Github [issues](https://github.com/fusion-energy/neutronics-workshop/issues)
+raise GitHub [issues](https://github.com/fusion-energy/neutronics-workshop/issues)
 or reach out in the [discussions](https://github.com/fusion-energy/neutronics-workshop/discussions)
 section if you spot anything that needs fixing or think of an improvement.
 Pull requests are very welcome.
@@ -31,7 +31,7 @@ The video below gives a brief explainer of what to expect in the workshop and so
 | [Task 1 - Cross sections](https://github.com/fusion-energy/neutronics-workshop/tree/main/tasks/task_01_cross_sections) | Nuclear data, cross-sections, MT numbers, Doppler | [link1](https://youtu.be/eBZ2lY_2v7I)  [link2](https://youtu.be/ELZNeIdSuMY) [link3](https://youtu.be/ec5BLLL6Q_g) [link4](https://youtu.be/mkl1mVnTO6g) |[![Task 1](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_1.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_1.yml)|
 | [Task 2 - Materials](https://github.com/fusion-energy/neutronics-workshop/tree/main/tasks/task_02_making_materials) | Materials, Neutronics Material Maker, Mixed materials | [link](https://youtu.be/-NGnY-1TWCA) | [![Task 2](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_2.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_2.yml) |
 | [Task 3 - CSG geometry](https://github.com/fusion-energy/neutronics-workshop/tree/main/tasks/task_03_making_CSG_geometry) | CSG geometry, Geometry visualisation | [link](https://youtu.be/Ovr7oYukYRw) | [![Task 3](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_3.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_3.yml) |
-| [Task 4 - Sources](https://github.com/fusion-energy/neutronics-workshop/tree/main/tasks/task_04_make_sources) | Neutron point sources, Gamma sources, Plasma sources, Neutron track visualisation | [link](https://youtu.be/j9dT1Viqcu4) | [![Task 4](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_4.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_4.yml) |
+| [Task 4 - Sources](https://github.com/fusion-energy/neutronics-workshop/tree/main/tasks/task_04_make_sources) | Neutron point sources, Gamma sources, Plasma sources, Neutron track visualization | [link](https://youtu.be/j9dT1Viqcu4) | [![Task 4](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_4.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_4.yml) |
 | [Task 5 - TBR](https://github.com/fusion-energy/neutronics-workshop/tree/main/tasks/task_05_CSG_cell_tally_TBR) | Tritium Breeding Ratio, Cell tallies, Simulations | [link](https://youtu.be/Vc7Qy7QW4o8) | [![Task 5](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_5.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_5.yml) |
 | [Task 6 - DPA](https://github.com/fusion-energy/neutronics-workshop/tree/main/tasks/task_06_CSG_cell_tally_DPA) | Displacements Per Atom, Cell tallies, Simulations, Volume calculations | [link](https://youtu.be/VLn59FSc4GA) | [![Task 6](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_6.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_6.yml) |
 | [Task 7 - Neutron and photon spectra](https://github.com/fusion-energy/neutronics-workshop/tree/main/tasks/task_07_CSG_cell_tally_spectra) | Neutron Spectra, Photon Spectra, Cell tallies, Energy group structures, Flux, Current | [link](https://youtu.be/qHqAuqMLYPA) | [![Task 7](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_7.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_7.yml) |
@@ -41,7 +41,7 @@ The video below gives a brief explainer of what to expect in the workshop and so
 | [Task 11 - CSG shut down Dose](https://github.com/fusion-energy/neutronics-workshop/tree/reshuffle/tasks/task_11_CSG_shut_down_dose_tallies) | Shut down Dose, Cell tallies, Dose coefficients |  |[![Task 11](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_11.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_11.yml)|
 | [Task 12 - Detector examples](https://github.com/fusion-energy/neutronics-workshop/tree/main/tasks/task_12_detector_examples) | Time filter detector response time of flight |  |[![Task 12](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_12.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_12.yml)|
 | [Task 13 - stochastic volume calculation](https://github.com/fusion-energy/neutronics-workshop/tree/main/tasks/task_13_stochastic_volume_calculation) | stochastic volume material atoms in cell |  |[![Task 13](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_13.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_13.yml)|
-| [Task 14 - Variance_reduction](https://github.com/fusion-energy/neutronics-workshop/tree/develop/tasks/task_14_variance_reduction) | Variance reduction, weight windows |  |[![Task 14](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_14.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_14.yml)|
+| [Task 14 - Variance_reduction](https://github.com/fusion-energy/neutronics-workshop/tree/main/tasks/task_14_variance_reduction) | Variance reduction, weight windows |  |[![Task 14](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_14.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_14.yml)|
 | [Task 15 - Making CAD geometry](https://github.com/fusion-energy/neutronics-workshop/tree/main/tasks/task_15_making_CAD_geometry) | Parametric CAD geometry, Paramak, Geometry visualisation | [link](https://www.youtube.com/watch?v=Bn_TcJSOvaA) |[![Task 15](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_15.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_15.yml)|
 | [Task 16 - CAD Cell tallies](https://github.com/fusion-energy/neutronics-workshop/tree/main/tasks/task_16_CAD_cell_tally_heat) | CAD-based neutronics, Cell tallies, DAGMC, Heating |  |[![Task 16](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_16.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_16.yml)|
 | [Task 17 - CAD Mesh tallies](https://github.com/fusion-energy/neutronics-workshop/tree/main/tasks/task_17_CAD_mesh_fast_flux) | CAD-based neutronics, Mesh tallies, Paramak, DAGMC, Fast flux |  |[![Task 17](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_17.yml/badge.svg?branch=main)](https://github.com/fusion-energy/neutronics-workshop/actions/workflows/ci_task_17.yml)|
@@ -100,14 +100,14 @@ commands in a terminal window.
       <summary><b>Expand</b> - Having permission denied errors?</summary>
         <pre><code class="language-html">
         If you are running the command from Linux or Ubuntu terminal and getting permission denied messages back.
-        Try running the same command with with elevated user permissions by adding sudo at the front.
+        Try running the same command with elevated user permissions by adding sudo at the front.
         sudo docker run -p 8888:8888 ghcr.io/fusion-energy/neutronics-workshop
         Then enter your password when prompted.
         </code></pre>
     </details>
 
 4. A URL should be displayed in the terminal and can now be opened in the
-internet browser of your choice. Select and open the URL at the end of the terminal print out (highlighted below)
+internet browser of your choice. Select and open the URL at the end of the terminal printout (highlighted below)
 
 <p align="center"><img src="https://user-images.githubusercontent.com/8583900/144759522-5306e61e-e30d-45e0-bb1a-ea8360e8c6da.png" width="70%" /></p>
 
@@ -118,7 +118,7 @@ To check the tasks run try opening the first task in the half day workshop folde
 This is not required for the half day workshop but some of the more advanced tasks do require Paraview and or FreeCAD.
 
 1. Some tasks require the use of Paraview to view the 3D meshes produced.
-Parview can be download from [here](https://www.paraview.org/download/).
+Parview can be downloaded from [here](https://www.paraview.org/download/).
     <details>
       <summary><b>Expand</b> - Ubuntu terminal commands for Paraview install</summary>
         <pre><code class="language-html">
@@ -137,7 +137,7 @@ FreeCAD is one option for this and can be downloaded [here](https://www.freecadw
 
 # Run in the cloud
 
-The repository is also ready for deployment on Github Codespaces which allows
+The repository is also ready for deployment on GitHub Codespaces which allows
 users to launch the containerized environment on more powerful cloud computers
 without installing anything locally.
 


### PR DESCRIPTION
The link to Task 14 is broken. 

![image](https://github.com/fusion-energy/neutronics-workshop/assets/40021217/09110c25-4665-4e4f-a479-3f08900b94a3)

This PR fixes this link and also fixes some typos in README by the way.