### PR TITLE
Adding meshsource example with a  regular mesh 

### DIFF
--- a/tasks/task_04_make_sources/6_mesh_source_with_strucutured_mesh.py
+++ b/tasks/task_04_make_sources/6_mesh_source_with_strucutured_mesh.py
@@ -1,4 +1,7 @@
+# this example shows users how to make a mesh source using a cylindrical mesh and a source term for each voxel.
 
+# this is a minimal example but a more realistic example could use the voxel location to look up properties
+# of the plasma at each coordinate and customize the source energy and strength at each mesh voxel location
 
 import openmc
 import numpy as np

--- a/tasks/task_04_make_sources/6_mesh_source_with_strucutured_mesh.py
+++ b/tasks/task_04_make_sources/6_mesh_source_with_strucutured_mesh.py
@@ -1,0 +1,23 @@
+
+
+import openmc
+
+sphere_surf_1 = openmc.Sphere(r=2000)
+sphere_region_1 = -sphere_surf_1
+sphere_cell_1 = openmc.Cell(region=sphere_region_1, )
+
+my_geometry = openmc.Geometry([sphere_cell_1])
+
+
+cylindrical_mesh = openmc.CylindricalMesh().from_domain(
+    my_geometry, # the corners of the mesh are being set automatically to surround the geometry
+    dimension=[10,10,10] # 10
+)
+
+centroids
+# for mesh_voxel in cylindrical_mesh.
+
+# mesh_source = openmc.MeshSource(
+#     mesh=cylindrical_mesh,
+#     sources 
+# )

--- a/tasks/task_04_make_sources/6_mesh_source_with_strucutured_mesh.py
+++ b/tasks/task_04_make_sources/6_mesh_source_with_strucutured_mesh.py
@@ -1,23 +1,59 @@
 
 
 import openmc
+import numpy as np
 
+openmc.config['cross_sections'] = '/home/j/endf-b8.0-hdf5/endfb-viii.0-hdf5/cross_sections.xml'
+
+# making a minimal geometry
 sphere_surf_1 = openmc.Sphere(r=2000)
-sphere_region_1 = -sphere_surf_1
-sphere_cell_1 = openmc.Cell(region=sphere_region_1, )
+sphere_cell_1 = openmc.Cell(region=-sphere_surf_1)
 
 my_geometry = openmc.Geometry([sphere_cell_1])
 
-
-cylindrical_mesh = openmc.CylindricalMesh().from_domain(
+# creating the mesh used for the mesh source
+cylindrical_mesh = openmc.CylindricalMesh.from_domain(
     my_geometry, # the corners of the mesh are being set automatically to surround the geometry
-    dimension=[10,10,10] # 10
+    dimension=[10,10,10]
 )
 
-centroids
-# for mesh_voxel in cylindrical_mesh.
+# empty list that will contain one source for each mesh voxel
+all_sources = []
+for i in cylindrical_mesh.indices:
 
-# mesh_source = openmc.MeshSource(
-#     mesh=cylindrical_mesh,
-#     sources 
-# )
+    mesh_index = (i[0]-1, i[1]-1, i[2]-1)
+    # this minimal example sets the same source for each voxel
+    # to create a realistic plasma source the mesh centroid could be used to
+    # find source strength, temperature and make a location specific source
+    # a function could be called that returns the temperature and relative source
+    # strength for each x,y,z or r, phi, z location
+    # voxel centroid can be obtained like this
+    # centroid = cylindrical_mesh.centroids[mesh_index]
+    # voxel centcylindrical_coords (z, phi, r) can be obtained like this
+    # cylindrical_coords = cylindrical_mesh.vertices_cylindrical[mesh_index]
+    volume = cylindrical_mesh.volumes[mesh_index]
+ 
+    # making a source for each voxel
+    my_source = openmc.IndependentSource()
+    my_source.energy = openmc.stats.Discrete([14.1e6], [1])
+    my_source.angle = openmc.stats.Isotropic()
+    if cylindrical_coords[2] > 1000: # filtering out sources below radius of 1000
+        my_source.strength = volume # uniform source
+    else:
+        my_source.strength = 0
+    all_sources.append(my_source)
+
+# creating the mesh source from the mesh and the list of sources
+mesh_source = openmc.MeshSource(
+    mesh=cylindrical_mesh,
+    sources=np.array(all_sources).reshape(cylindrical_mesh.dimension)
+)
+
+# Update all element source strengths such that they sum to 1.0.
+# this makes post processing the results easier if the total source strength is 1
+mesh_source.normalize_source_strengths()
+
+# plotting the mesh source
+from openmc_source_plotter import plot_source_position
+plot = plot_source_position([mesh_source], n_samples=10000)
+plot.show()

--- a/tasks/task_04_make_sources/6_mesh_source_with_strucutured_mesh.py
+++ b/tasks/task_04_make_sources/6_mesh_source_with_strucutured_mesh.py
@@ -32,8 +32,8 @@ for i in cylindrical_mesh.indices:
     # strength for each x,y,z or r, phi, z location
     # voxel centroid can be obtained like this
     # centroid = cylindrical_mesh.centroids[mesh_index]
-    # voxel centcylindrical_coords (z, phi, r) can be obtained like this
-    # cylindrical_coords = cylindrical_mesh.vertices_cylindrical[mesh_index]
+    # voxel cylindrical_coords (z, phi, r) can be obtained like this
+    cylindrical_coords = cylindrical_mesh.vertices_cylindrical[mesh_index]
     volume = cylindrical_mesh.volumes[mesh_index]
  
     # making a source for each voxel


### PR DESCRIPTION
this example shows users how to make a mesh source using a cylindrical mesh and a source term for each voxel.

this is a minimal example but a more realistic example could use the voxel location to look up properties of the plasma at each coordinate and customize the source energy and strength at each mesh voxel location

this could be combined with a function that looks up the location properties in the plasma and customizes (e.g temperature, strength) the source at that mexh voxel location for each source. For now I've put in a simple filter to set voxels with a radius below a limit to strength = 0

meshsource was added recently to the openmc develop branch and will be in the next release (which should be before TOFE conference)

![Screenshot from 2024-03-29 22-38-17](https://github.com/fusion-energy/neutronics-workshop/assets/8583900/3083b972-79e6-4029-ba79-4b5ea7a515df)

