### PR TITLE
adding fw cadis varience reduction example

### DIFF
--- a/tasks/task_14_variance_reduction/5_shielded_room_fw_cadis_ww.ipynb
+++ b/tasks/task_14_variance_reduction/5_shielded_room_fw_cadis_ww.ipynb
@@ -655,6 +655,7 @@
     "upper_right = ( pitch,  pitch,  pitch)\n",
     "uniform_dist = openmc.stats.Box(lower_left, upper_right)\n",
     "settings.random_ray['ray_source'] = openmc.IndependentSource(space=uniform_dist)\n",
+    "settings.random_ray['source_region_meshes'] = [(mesh, [geometry.root_universe])]\n",
     "\n",
     "settings.max_history_splits = 1_000  # controls the maximum partile splits over the entire lifetime of the particle\n",
     "\n",


### PR DESCRIPTION
Work in progress but this notebook aims to be an example simulation using the recently added FW-CADIS feature.

TODO
- [ ] mgxs generation   <- currently failing to write mgxs.h5 file with openmc error
- [ ] random ray simulation
- [ ] weight window generation simulation with weight window usage simulation