### PR TITLE
Addition of build for linux/arm64 to allow macbooks to use image.

### DIFF
--- a/.github/workflows/docker-publish-base.yml
+++ b/.github/workflows/docker-publish-base.yml
@@ -33,3 +33,4 @@ jobs:
           file: .devcontainer/base.Dockerfile
           push: true
           tags: ghcr.io/fusion-energy/neutronics-workshop:base
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,3 +35,4 @@ jobs:
           push: true
           file: .devcontainer/Dockerfile
           tags: ghcr.io/fusion-energy/neutronics-workshop
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Modification to docker-publish.yml build two images, for arm64 and amd64 processors. 