### PR TITLE
removing openmc-dagmc-wrapper

### DIFF
--- a/.devcontainer/base.Dockerfile
+++ b/.devcontainer/base.Dockerfile
@@ -97,7 +97,6 @@ RUN pip install --upgrade pip
 RUN pip install neutronics_material_maker[density] \
                 stl_to_h5m \
                 remove_dagmc_tags \
-                openmc-dagmc-wrapper \
                 openmc-tally-unit-converter \
                 regular_mesh_plotter \
                 spectrum_plotter \


### PR DESCRIPTION
we don't actually use this package in the workshop anymore so it can be removed