### PR TITLE
Update 1_shielded_room_survival_biasing.ipynb

### DIFF
--- a/tasks/task_14_variance_reduction/1_shielded_room_survival_biasing.ipynb
+++ b/tasks/task_14_variance_reduction/1_shielded_room_survival_biasing.ipynb
@@ -311,6 +311,7 @@
    "source": [
     "def run_and_plot(model, image_filename):\n",
     "\n",
+    "    !rm *.h5 || true\n",
     "    sp_filename = model.run()\n",
     "\n",
     "    with openmc.StatePoint(sp_filename) as sp:\n",


### PR DESCRIPTION
Add `!rm *.h5 || true` prior to running new `Model` to remove erroneous old `*.h5` files as seen in task 13