### PR TITLE
not transporting on activated mat

### DIFF
--- a/tasks/task_20_CAD_shut_down_dose_rate/2_unstructured_mesh_R2S_shutdown_dose_rate_several_materials.ipynb
+++ b/tasks/task_20_CAD_shut_down_dose_rate/2_unstructured_mesh_R2S_shutdown_dose_rate_several_materials.ipynb
@@ -1,0 +1,634 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "503ef128",
+   "metadata": {},
+   "source": [
+    "# Unstructured mesh R2S shutdown dose rate with different materials\n",
+    "\n",
+    "In this example, we perform a shutdown dose rate simulation using the R2S method on an unstructured mesh.\n",
+    "\n",
+    "This is an upgraded example that includes three cells, three materials (instead of one) and two cooling timesteps\n",
+    "\n",
+    "When material regions are in contact, it's possible for a single tetrahedral element to contain multiple materials. This must be carefully accounted for when depleting the element volume\n",
+    "\n",
+    "First, we import all the necessary packages for the simulation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83e65ae5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cad_to_dagmc import CadToDagmc\n",
+    "import cadquery as cq\n",
+    "import openmc\n",
+    "from matplotlib.colors import LogNorm\n",
+    "import openmc.deplete\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6aed89eb",
+   "metadata": {},
+   "source": [
+    "Then we sets the cross section path to the correct location in the docker image.\n",
+    "If you are running this outside the docker image you will have to change this path to your local cross section path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b518ee5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "openmc.config['chain_file'] = Path.home() / 'nuclear_data' / 'chain-endf-b8.0.xml'\n",
+    "openmc.config['cross_sections'] = Path.home() / 'nuclear_data' / 'cross_sections.xml'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f5c512b",
+   "metadata": {},
+   "source": [
+    "makes a CAD geometry to use for the neutronics geometry\n",
+    "\n",
+    "three volumes and three material tags, one for each letter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "535f6dd2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text = cq.Workplane().text(txt=\"R2S\", fontsize=10, distance=1)\n",
+    "\n",
+    "my_model = CadToDagmc()\n",
+    "my_model.add_cadquery_object(\n",
+    "    cadquery_object=text,\n",
+    "    material_tags=[\n",
+    "        \"mat1\",\n",
+    "        \"mat2\",\n",
+    "        \"mat3\",\n",
+    "    ],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f9287ed",
+   "metadata": {},
+   "source": [
+    "Convert the CAD geometry to a DAGMC surface mesh and MOAB volume mesh. This conversion ensures that the surface mesh matches the outer surface of the volume mesh. This helps ensure that tetrahedral elements have a single material within."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a01630c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dagmc_filename, umesh_filename = my_model.export_dagmc_h5m_file(\n",
+    "    filename=\"dagmc.h5m\",\n",
+    "    max_mesh_size=10,\n",
+    "    min_mesh_size=2,\n",
+    "    unstructured_volumes=[1,2,3],\n",
+    "    umesh_filename=\"umesh.vtk\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1dd5df51",
+   "metadata": {},
+   "source": [
+    "Now use the two meshes in OpenMC to make the DAGMCUniverse and the UnstructuredMesh\n",
+    "\n",
+    "We transport particles on the DAGMCUniverse\n",
+    "\n",
+    "We will get the flux on the UnstructuredMesh tets and then activate the materials on each tet and use this information to make source terms"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "133f360e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add adding distance to avoid source being born on edge of geometry and the 2nd simulation crashing\n",
+    "universe = openmc.DAGMCUniverse(\"dagmc.h5m\").bounded_universe()\n",
+    "my_geometry = openmc.Geometry(universe)\n",
+    "\n",
+    "# the unstructured mesh to overlay on the DAGMC geometry\n",
+    "umesh = openmc.UnstructuredMesh(\"umesh.vtk\", library=\"moab\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "97bf682a",
+   "metadata": {},
+   "source": [
+    "Define the materials used in the simulation.\n",
+    "\n",
+    "The number of material names must match the number of tags included in the DAGMC file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4f284bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fe_material = openmc.Material(name='mat1')\n",
+    "fe_material.add_nuclide(\"Fe56\", 1, percent_type=\"ao\") \n",
+    "fe_material.set_density(\"g/cm3\", 7.874)\n",
+    "fe_material.depletable = True\n",
+    "\n",
+    "Li4SiO4_mat = openmc.Material(name='mat2')\n",
+    "Li4SiO4_mat.add_element('Li', 4.0, percent_type='ao')\n",
+    "Li4SiO4_mat.add_element('Si', 1.0, percent_type='ao')\n",
+    "Li4SiO4_mat.add_element('O', 4.0, percent_type='ao')\n",
+    "Li4SiO4_mat.set_density('g/cm3', 2.32) \n",
+    "Li4SiO4_mat.depletable = True\n",
+    "\n",
+    "water_mat = openmc.Material(name='mat3')\n",
+    "water_mat.add_element('H', 2.0, percent_type='ao')\n",
+    "water_mat.add_element('O', 1.0, percent_type='ao')\n",
+    "water_mat.set_density('g/cm3', 0.99821) \n",
+    "water_mat.depletable = True\n",
+    "\n",
+    "\n",
+    "my_materials = openmc.Materials([fe_material, Li4SiO4_mat, water_mat])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c485f3a3",
+   "metadata": {},
+   "source": [
+    "Make a simple neutron source in the center of the geometry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48e3019f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a DT point source\n",
+    "my_source = openmc.IndependentSource()\n",
+    "my_source.space = openmc.stats.Point(my_geometry.bounding_box.center)\n",
+    "my_source.angle = openmc.stats.Isotropic()\n",
+    "my_source.energy = openmc.stats.Discrete([14e6], [1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a53f0f34",
+   "metadata": {},
+   "source": [
+    "Make the simulation settings for the neutron irradiation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcf2675b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_settings = openmc.Settings()\n",
+    "my_settings.batches = 5\n",
+    "my_settings.particles = 5000\n",
+    "my_settings.run_mode = \"fixed source\"\n",
+    "my_settings.output = {'summary': False}\n",
+    "my_settings.source = my_source"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c820f8a",
+   "metadata": {},
+   "source": [
+    "Make the neutron irradiation model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efc33788",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = openmc.model.Model(my_geometry, my_materials, my_settings) \n",
+    "model.export_to_xml()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "731d930b",
+   "metadata": {},
+   "source": [
+    "Collect a list of all nuclides present in the model\n",
+    "\n",
+    "Get the flux and micro_xs in each unstructured mesh tet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d119240c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "all_nuclides = set()\n",
+    "for material in my_materials:\n",
+    "    all_nuclides.update(material.get_nuclides())\n",
+    "\n",
+    "flux_in_each_voxel, micro_xs = openmc.deplete.get_microxs_and_flux(\n",
+    "    model=model,\n",
+    "    domains=umesh,\n",
+    "    energies=[0, 30e6], # one energy bin from 0 to 30MeV\n",
+    "    chain_file=openmc.config['chain_file'],\n",
+    "    # needed otherwise the statepoint file is produced in an unknown temporary directory\n",
+    "    run_kwargs={'cwd':'.'},\n",
+    "    nuclides=list(all_nuclides)  # Convert set to list\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f60c828",
+   "metadata": {},
+   "source": [
+    "Read in the unstructured from the statepoint, this contains additional information (centroids and volumes) compared to the umesh object"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84ee00fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sp_filename=f'statepoint.{my_settings.batches}.h5'\n",
+    "sp = openmc.StatePoint(sp_filename)\n",
+    "\n",
+    "# normally with regular meshes I would get the mesh from the tally\n",
+    "# but with unstructured meshes the tally does not contain the mesh\n",
+    "# however we can get it from the statepoint file\n",
+    "umesh_from_sp = sp.meshes[umesh.id]\n",
+    "# reading a unstructured mesh from the statepoint trigger internal code in the mesh\n",
+    "#  object so that its centroids and volumes become known.\n",
+    "# centroids and volumes are needed for the get_values and write_data_to_vtk steps\n",
+    "centroids = umesh_from_sp.centroids\n",
+    "mesh_vols = umesh_from_sp.volumes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d70db52a",
+   "metadata": {},
+   "source": [
+    "Calcualte the material volumes for each mesh element from the unstructured mesh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14f73698",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mat_vols = umesh_from_sp.material_volumes(model=model,n_samples=1_000_000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "231d81e5",
+   "metadata": {},
+   "source": [
+    "Make a new fresh material for every tet in the unstructured mesh.\n",
+    "\n",
+    "Assign the material volume for each tet as the volume is needed to deplete the material."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a6a355da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get material IDs from my_materials object\n",
+    "material_ids = [mat.id for mat in my_materials]\n",
+    "\n",
+    "materials_for_every_mesh_voxel = []\n",
+    "for i in range(len(mat_vols[material_ids[0]])):\n",
+    "    # Find which material is present in this voxel (only one material per voxel)\n",
+    "    material_id = next(mid for mid in material_ids if mat_vols[mid][i] > 0)\n",
+    "    material = next(mat for mat in my_materials if mat.id == material_id)\n",
+    "    \n",
+    "    # Create a new material instance for this voxel\n",
+    "    new_mat = material.clone()\n",
+    "    new_mat.id = i\n",
+    "    # Use the volume of this material in this voxel from mat_vol\n",
+    "    new_mat.volume = mat_vols[material_id][i]\n",
+    "    materials_for_every_mesh_voxel.append(new_mat) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a76e4561",
+   "metadata": {},
+   "source": [
+    "Define irradiation and cooling time steps.\n",
+    "\n",
+    "Set source rates to zero during decay-only steps.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cd1980e8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "timesteps_and_source_rates = [\n",
+    "    (5, 1e20),  # 5 second  \n",
+    "    (60, 0),  # 60 seconds\n",
+    "    (60, 0) # 60 seconds\n",
+    "]\n",
+    "\n",
+    "timesteps = [item[0] for item in timesteps_and_source_rates]\n",
+    "source_rates = [item[1] for item in timesteps_and_source_rates]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c158e360",
+   "metadata": {},
+   "source": [
+    "Perform the activation / depletion / transmutation of all the materials"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3de1bbd8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# constructing the operator, note we pass in the flux and micro xs\n",
+    "operator = openmc.deplete.IndependentOperator(\n",
+    "    materials=openmc.Materials(materials_for_every_mesh_voxel),\n",
+    "    fluxes=[flux[0] for flux in flux_in_each_voxel],  # Flux in each group in [n-cm/src] for each domain\n",
+    "    micros=micro_xs,\n",
+    "    reduce_chain_level=5,\n",
+    "    normalization_mode=\"source-rate\"\n",
+    ")\n",
+    "\n",
+    "integrator = openmc.deplete.PredictorIntegrator(\n",
+    "    operator=operator,\n",
+    "    timesteps=timesteps,\n",
+    "    source_rates=source_rates, # a 5 second pulse of neutrons followed by 120 seconds of decay\n",
+    "    timestep_units='s'\n",
+    ")\n",
+    "\n",
+    "integrator.integrate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da828bd4",
+   "metadata": {},
+   "source": [
+    "Make a dose tally on a regular mesh for the photon / gamma dose.\n",
+    "\n",
+    "The tallies will be used in each of the gamma simulations to see the shutdown dose"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4ab1b79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "energies, pSv_cm2 = openmc.data.dose_coefficients(particle=\"photon\", geometry=\"AP\")\n",
+    "dose_filter = openmc.EnergyFunctionFilter(\n",
+    "    energies, pSv_cm2, interpolation=\"cubic\"  # interpolation method recommended by ICRP\n",
+    ")\n",
+    "\n",
+    "regularmesh = openmc.RegularMesh().from_domain(\n",
+    "    my_geometry,\n",
+    "    dimension=[30, 30, 30],  # 30 voxels in each axis direction (x, y, z)\n",
+    ")\n",
+    "\n",
+    "particle_filter = openmc.ParticleFilter([\"photon\"])\n",
+    "mesh_filter = openmc.MeshFilter(regularmesh)\n",
+    "dose_tally = openmc.Tally()\n",
+    "dose_tally.filters = [mesh_filter, dose_filter, particle_filter]\n",
+    "dose_tally.scores = [\"flux\"]\n",
+    "dose_tally.name = \"photon_dose_on_mesh\"\n",
+    "tallies = openmc.Tallies([dose_tally])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e4f26ed",
+   "metadata": {},
+   "source": [
+    "We will collect the gamma source for all cooling time steps\n",
+    "\n",
+    "Extract all the materials and get their gamma emission spectrum\n",
+    "\n",
+    "Turn these gamma spectra into source terms for later use"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c1b18a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = openmc.deplete.Results.from_hdf5(\"depletion_results.h5\")\n",
+    "\n",
+    "all_mesh_sources = []\n",
+    "for i_cool in range(1,len(timesteps)):  # skip the first time step as it is the irradiation step\n",
+    "    all_sources = []\n",
+    "    for i, mesh_vol in enumerate(mesh_vols):\n",
+    "        material_id = str(i)\n",
+    "\n",
+    "        activated_material = results[i_cool].get_material(material_id)\n",
+    "        activated_material.volume = mesh_vol\n",
+    "        energy = activated_material.get_decay_photon_energy(\n",
+    "            clip_tolerance = 1e-6,\n",
+    "            units = 'Bq',\n",
+    "        )\n",
+    "\n",
+    "        if energy:\n",
+    "            strength = energy.integral()\n",
+    "        # for the strength == None case\n",
+    "        else:\n",
+    "            strength = 0\n",
+    "\n",
+    "        my_source = openmc.IndependentSource(\n",
+    "            energy=energy,\n",
+    "            particle = \"photon\",\n",
+    "            strength = strength,\n",
+    "            # constraints={'domains':my_material}\n",
+    "        )\n",
+    "\n",
+    "        all_sources.append(my_source)\n",
+    "\n",
+    "    # Make a mesh source out of the IndependentSource just made in the inner loop\n",
+    "    mesh_source = openmc.MeshSource(\n",
+    "        mesh=umesh_from_sp,\n",
+    "        sources=all_sources,\n",
+    "    )\n",
+    "\n",
+    "    all_mesh_sources.append(mesh_source)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35ee7bc2",
+   "metadata": {},
+   "source": [
+    "Makes and runs a simulation model for each time meshsource that has been made."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0cef5d75",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Make simulation settings for the gamma transport simulation\n",
+    "my_gamma_settings = openmc.Settings()\n",
+    "my_gamma_settings.run_mode = \"fixed source\"\n",
+    "my_gamma_settings.batches = 10\n",
+    "my_gamma_settings.particles = 1000000\n",
+    "my_gamma_settings.output = {'summary': False}\n",
+    "my_gamma_settings.photon_transport = True\n",
+    "\n",
+    "all_gamma_sp_filename = []\n",
+    "\n",
+    "for mesh_source in all_mesh_sources:\n",
+    "    \n",
+    "    my_gamma_settings.source = mesh_source\n",
+    "\n",
+    "    # here we use the same pristine materials from before neutron irradaiton as the burnup is low\n",
+    "    # and the materials have not changed much so they would not perterb the neutron spectrum significantly\n",
+    "    # you could also use the activated materials from the depletion results but this would significantly slow the simulation down\n",
+    "    model_gamma = openmc.Model(my_geometry, my_materials, my_gamma_settings, tallies)\n",
+    "\n",
+    "    # Make the model for the gamma / photon transport and run the simulation\n",
+    "    # a folder will be made for each photon transposrt, XML files will be saves there as well as the plot\n",
+    "    # Create directories with parents=True to ensure parent directories are created\n",
+    "    output_dir = Path(f\"photons/photon_at_time_{i_cool}\")\n",
+    "    output_dir.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "    gamma_sp_filename = model_gamma.run(cwd=str(output_dir))\n",
+    "    all_gamma_sp_filename.append(gamma_sp_filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "935c7cbf",
+   "metadata": {},
+   "source": [
+    "Loads up each of the simulation and plots the results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7bdd12a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openmc_regular_mesh_plotter import plot_mesh_tally\n",
+    "\n",
+    "for gamma_sp_filename in all_gamma_sp_filename:\n",
+    "# You may wish to plot the dose tally on a mesh, this package makes it easy to include the geometry with the mesh tally\n",
+    "    with openmc.StatePoint(gamma_sp_filename) as statepoint:\n",
+    "        photon_tally = statepoint.get_tally(name=\"photon_dose_on_mesh\")\n",
+    "\n",
+    "        pico_to_micro = 1e-6\n",
+    "        seconds_to_hours = 60*60\n",
+    "        scaling_factor = (seconds_to_hours * pico_to_micro) / regularmesh.volumes[0][0][0]\n",
+    "\n",
+    "        plot = plot_mesh_tally(\n",
+    "                tally=photon_tally,\n",
+    "                basis=\"xy\",\n",
+    "                # score='flux', # only one tally so can make use of default here\n",
+    "                value=\"mean\",\n",
+    "                colorbar_kwargs={\n",
+    "                    'label': \"Decay photon dose [µSv/h]\",\n",
+    "                },\n",
+    "                norm=LogNorm(),\n",
+    "                volume_normalization=False,\n",
+    "                scaling_factor=scaling_factor,\n",
+    "            )\n",
+    "        plot.figure.savefig(output_dir / f'shut_down_dose_map_timestep_{i_cool}.png')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b29028e9",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6699c6aa",
+   "metadata": {},
+   "source": [
+    "You may want to increase the resolution of the regularmesh and rerun the simulation\n",
+    "\n",
+    "I can also recommend talking a look shutdown dose rate simulations using the D1S\n",
+    "\n",
+    "D1S is generally quicker than R2S.\n",
+    "\n",
+    "R2S allows the user the possibility of changing the geometry between the neutron and gamma simulation.\n",
+    "This can be useful for doing shutdown dose rate simulations with moving geometry of geometry that has been irradiated in one position then moved for maintenance and is still active."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".neutronicsworkshop",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I'm just tiding up the new r2s example

- renamed file so that it does not have a space in the filename and can therefore be included in the online docs (now it is live)
- using the pristine materials to do gamma transport, added code comment on this
- refactored large loop into three stages
- removed parts that don't change from loops (tallies, regularmesh creation, most of the settings)
- plotting xy not xz plane so letters can be seen
- added more comments

@fnovais11 I reworked the example a bit, the material change I made should further speed up the example.

Also the example is now live on the docs page here
https://fusion-energy.github.io/neutronics-workshop/html/tasks/task_20_CAD_shut_down_dose_rate/2_unstructured_mesh_R2S_shutdown_dose_rate_several_materials.html