### PR TITLE
Volume fraction on Task 2_5_example_materials_mixed.ipynb

### DIFF
--- a/tasks/task_02_making_materials/5_example_materials_mixed.ipynb
+++ b/tasks/task_02_making_materials/5_example_materials_mixed.ipynb
@@ -78,7 +78,7 @@
     "        steel_mat,\n",
     "        h20_mat,\n",
     "        ],\n",
-    "    fracs=[0.7, 0.2], # list of combination fractions for each material\n",
+    "    fracs=[0.7, 0.3], # list of combination fractions for each material\n",
     "    percent_type='vo') # combination fraction type is by volume\n",
     "\n",
     "mixed_mat"


### PR DESCRIPTION
The volume fractions didn't add up to 1, letting a void fraction of 0.1. I am not sure this is normal.