### PR TITLE
removed max_realizations argument from fw cadis weight window generation

### DIFF
--- a/tasks/task_14_variance_reduction/5_shielded_room_fw_cadis.ipynb
+++ b/tasks/task_14_variance_reduction/5_shielded_room_fw_cadis.ipynb
@@ -415,7 +415,6 @@
     "rr_model.settings.weight_window_generators = openmc.WeightWindowGenerator(\n",
     "    method='fw_cadis',\n",
     "    mesh=mesh,\n",
-    "    max_realizations=settings.batches\n",
     ")"
    ]
   },


### PR DESCRIPTION
due to the recent merge of this PRs into openmc we no longer need the max_realizations argument :tada: 

https://github.com/openmc-dev/openmc/pull/3616