### PR TITLE
Using vtkhdf format instead of older vtk format for unstructured mesh file export

### DIFF
--- a/tasks/task_18_CAD_mesh_fast_flux/1_simulate_fast_neutron_flux_on_cad.ipynb
+++ b/tasks/task_18_CAD_mesh_fast_flux/1_simulate_fast_neutron_flux_on_cad.ipynb
@@ -201,7 +201,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The tally data along with the mesh is then saved to a vtkhdf format file. You could also save to the older .vtk file extention if prefered. I am using vtkhdf as is results in a smaller more performat file."
+    "The tally data along with the mesh is then saved to a vtkhdf format file. You could also save to the older .vtk file extention if prefered. I am using vtkhdf as is results in a smaller more performant file."
    ]
   },
   {


### PR DESCRIPTION
this needs the latest develop branch of openmc but as we have that on the wheel we can now use vtkhdf format here :tada: 