### PR TITLE
Fix tokamak_source API and shallow-clone install docs

### DIFF
--- a/docs/install_conda.md
+++ b/docs/install_conda.md
@@ -16,7 +16,7 @@ Once you have a version of Conda installed then proceed with cloning or [downloa
 
 ```bash
 sudo apt-get install git
-git clone https://github.com/fusion-energy/neutronics-workshop.git
+git clone --depth 1 --branch main https://github.com/fusion-energy/neutronics-workshop.git
 cd neutronics-workshop
 ```
 

--- a/docs/install_mamba.md
+++ b/docs/install_mamba.md
@@ -19,7 +19,7 @@ Once you have a version of Conda installed then proceed with cloning or [downloa
 
 ```bash
 sudo apt-get install git
-git clone https://github.com/fusion-energy/neutronics-workshop.git
+git clone --depth 1 --branch main https://github.com/fusion-energy/neutronics-workshop.git
 cd neutronics-workshop
 ```
 
@@ -43,7 +43,7 @@ bash postBuild
 Clone or otherwise [download](https://github.com/fusion-energy/neutronics-workshop/archive/refs/heads/main.zip) the repository and cd into the repository directory.
 
 ```bash
-git clone https://github.com/fusion-energy/neutronics-workshop.git
+git clone --depth 1 --branch main https://github.com/fusion-energy/neutronics-workshop.git
 cd neutronics-workshop
 ```
 

--- a/docs/install_pip.md
+++ b/docs/install_pip.md
@@ -18,7 +18,7 @@ Once you have a version of Conda installed then proceed with cloning or [downloa
 
 ```bash
 sudo apt-get install git
-git clone https://github.com/fusion-energy/neutronics-workshop.git
+git clone --depth 1 --branch main https://github.com/fusion-energy/neutronics-workshop.git
 cd neutronics-workshop
 ```
 

--- a/tasks/half-day-university-workshop/task_09.ipynb
+++ b/tasks/half-day-university-workshop/task_09.ipynb
@@ -56,30 +56,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from openmc_plasma_source import tokamak_source\n",
-    "\n",
-    "my_sources = tokamak_source(\n",
-    "    elongation=1.557,\n",
-    "    ion_density_centre=1.09e20,\n",
-    "    ion_density_peaking_factor=1,\n",
-    "    ion_density_pedestal=1.09e20,\n",
-    "    ion_density_separatrix=3e19,\n",
-    "    ion_temperature_centre=45.9,\n",
-    "    ion_temperature_peaking_factor=8.06,\n",
-    "    ion_temperature_pedestal=6.09,\n",
-    "    ion_temperature_separatrix=0.1,\n",
-    "    major_radius=9.06,\n",
-    "    minor_radius=2.92258,\n",
-    "    pedestal_radius=0.8 * 2.92258,\n",
-    "    mode=\"H\",\n",
-    "    shafranov_factor=0.44789,\n",
-    "    triangularity=0.270,\n",
-    "    ion_temperature_beta=6,\n",
-    "    sample_size=50,  # the number of individual sources to use to make a combined source\n",
-    "    angles=(0, 2 * 3.14)  # angle in radians\n",
-    ") # returns a list of openmc sources"
-   ]
+   "source": "from openmc_plasma_source import tokamak_source\n\nmy_sources = tokamak_source(\n    elongation=1.557,\n    ion_density_centre=1.09e20,\n    ion_density_peaking_factor=1,\n    ion_density_pedestal=1.09e20,\n    ion_density_separatrix=3e19,\n    ion_temperature_centre=45.9,\n    ion_temperature_peaking_factor=8.06,\n    ion_temperature_pedestal=6.09,\n    ion_temperature_separatrix=0.1,\n    major_radius=9.06,\n    minor_radius=2.92258,\n    pedestal_radius=0.8 * 2.92258,\n    mode=\"H\",\n    shafranov_factor=0.44789,\n    triangularity=0.270,\n    ion_temperature_beta=6,\n    angles=(0, 2 * 3.14)  # angle in radians\n) # returns an openmc MeshSource"
   },
   {
    "attachments": {},

--- a/tasks/task_04_make_sources/3_plasma_source_plots.ipynb
+++ b/tasks/task_04_make_sources/3_plasma_source_plots.ipynb
@@ -56,30 +56,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "from openmc_plasma_source import tokamak_source\n",
-    "\n",
-    "my_sources = tokamak_source(\n",
-    "    elongation=1.557,\n",
-    "    ion_density_centre=1.09e20,\n",
-    "    ion_density_peaking_factor=1,\n",
-    "    ion_density_pedestal=1.09e20,\n",
-    "    ion_density_separatrix=3e19,\n",
-    "    ion_temperature_centre=45.9,\n",
-    "    ion_temperature_peaking_factor=8.06,\n",
-    "    ion_temperature_pedestal=6.09,\n",
-    "    ion_temperature_separatrix=0.1,\n",
-    "    major_radius=9.06,\n",
-    "    minor_radius=2.92258,\n",
-    "    pedestal_radius=0.8 * 2.92258,\n",
-    "    mode=\"H\",\n",
-    "    shafranov_factor=0.44789,\n",
-    "    triangularity=0.270,\n",
-    "    ion_temperature_beta=6,\n",
-    "    sample_size=50,  # the number of individual sources to use to make a combined source\n",
-    "    angles=(0, 2 * 3.14)  # angle in radians\n",
-    ") # returns a list of openmc sources"
-   ]
+   "source": "from openmc_plasma_source import tokamak_source\n\nmy_sources = tokamak_source(\n    elongation=1.557,\n    ion_density_centre=1.09e20,\n    ion_density_peaking_factor=1,\n    ion_density_pedestal=1.09e20,\n    ion_density_separatrix=3e19,\n    ion_temperature_centre=45.9,\n    ion_temperature_peaking_factor=8.06,\n    ion_temperature_pedestal=6.09,\n    ion_temperature_separatrix=0.1,\n    major_radius=9.06,\n    minor_radius=2.92258,\n    pedestal_radius=0.8 * 2.92258,\n    mode=\"H\",\n    shafranov_factor=0.44789,\n    triangularity=0.270,\n    ion_temperature_beta=6,\n    angles=(0, 2 * 3.14)  # angle in radians\n) # returns an openmc MeshSource"
   },
   {
    "attachments": {},


### PR DESCRIPTION
## Summary
- Fixes the `tokamak_source()` `CellExecutionError` caused by the updated `openmc_plasma_source` API. The `sample_size` argument was removed upstream; `tokamak_source()` now returns a single `openmc.source.MeshSource` instead of a list of sources.
- Removed `sample_size=50` from the calls in:
  - `tasks/half-day-university-workshop/task_09.ipynb`
  - `tasks/task_04_make_sources/3_plasma_source_plots.ipynb`
  - and updated the trailing comment to reflect the new return type.
- Reduced clone size in the install docs by switching to a shallow, single-branch clone (`--depth 1 --branch main`) in `docs/install_conda.md`, `docs/install_pip.md`, and `docs/install_mamba.md`.

## Testing
- Verified the updated `tokamak_source()` call succeeds and returns an `openmc.source.MeshSource`.
