### PR TITLE
docs: update tokamak_source mesh_resolution to (r, z) 2-tuple for openmc-plasma-source 0.7.0

### DIFF
--- a/docs/agents/sources.md
+++ b/docs/agents/sources.md
@@ -95,7 +95,7 @@ my_sources = tokamak_source(
     ion_temperature_peaking_factor=8.06, ion_temperature_beta=6,
     shafranov_factor=0.44789,
     mode='H',
-    mesh_resolution=(100, 1, 100),      # mesh bins in (r, phi, z)
+    mesh_resolution=(100, 100),         # mesh bins in (r, z)
     start_angle=0, rotation_angle=2*3.14159,  # toroidal start angle and extent in radians
 )
 


### PR DESCRIPTION
Updates the `tokamak_source` example in the agent source docs to match **openmc-plasma-source 0.7.0**.

In 0.7.0, `mesh_resolution` changed from a 3-tuple `(n_r, n_phi, n_z)` to a 2-tuple `(n_r, n_z)` — the toroidal dimension was removed because the source is axisymmetric (density and temperature depend only on the minor radius), so the toroidal mesh resolution was a no-op. Passing the old 3-tuple now raises a `ValueError`.

## Change

- `docs/agents/sources.md`: `mesh_resolution=(100, 1, 100)` → `mesh_resolution=(100, 100)`.

## Notes

- The dependency is unpinned in `requirements.txt` and `environment.yml`, so CI already picks up 0.7.0.
- The executed notebooks (`task_04/3_plasma_source_plots.ipynb`, `task_09`) don't pass `mesh_resolution` — they rely on the default, which is now `(100, 100)` — so they are unaffected. This was the only old-API reference in the repo.
