### PR TITLE
Fix typo and surface area calculation

### DIFF
--- a/tasks/task_09_CSG_instantaneous_dose_tallies/1_surface_dose_from_gamma_source.ipynb
+++ b/tasks/task_09_CSG_instantaneous_dose_tallies/1_surface_dose_from_gamma_source.ipynb
@@ -22,7 +22,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The effective dose deposited by a neutron or photon depends on the energy of the particle. The dose coefficients provided by ICRP are energy dependant.\n",
+    "The effective dose deposited by a neutron or photon depends on the energy of the particle. The dose coefficients provided by ICRP are energy dependent.\n",
     "\n",
     "The following section plots effective dose coefficient as a function of incident particle energy for neutrons and photons."
    ]
@@ -55,9 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "energy_bins_n, dose_coeffs_n = openmc.data.dose_coefficients(\n",
@@ -135,9 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "height = 100\n",
@@ -200,9 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -341,7 +335,8 @@
     "tally_std_dev = df['std. dev.'].sum()\n",
     "\n",
     "# convert from the tally output units of pSv cm² to pSv by dividing by the surface area of the surface\n",
-    "dose_in_pSv = tally_result / (4 * math.pi * math.pow(200, 2))\n",
+    "sphere_radius = sphere_1.r\n",
+    "dose_in_pSv = tally_result / (4 * math.pi * sphere_radius**2)\n",
     "\n",
     "source_activity = 56000  # in decays per second (Bq)\n",
     "emission_rate = 2  # the number of gammas emitted per decay which is approximately 2 for Co60\n",


### PR DESCRIPTION
## Description
The previous implementation used a hard-coded radius value of 200 cm when converting surface tally results to dose. However, the actual geometry defines sphere_1 with a radius of 100 cm.

This PR replaces the hard-coded value with sphere_1.r to ensure consistency between geometry definition and post-processing.