### PR TITLE
no longer need energies arg in get_microxs_and_flux

### DIFF
--- a/tasks/half-day-university-workshop/task_17/task_17.ipynb
+++ b/tasks/half-day-university-workshop/task_17/task_17.ipynb
@@ -197,7 +197,6 @@
     "flux_in_each_group, micro_xs = openmc.deplete.get_microxs_and_flux(\n",
     "    model=model,\n",
     "    domains=[shield_cell],\n",
-    "    energies=[0, 30e6], # one energy bin from 0 to 30MeV\n",
     "    chain_file=openmc.config['chain_file'],\n",
     ")"
    ]

--- a/tasks/task_10_activation_transmutation_depletion/5_full_pulse_schedule.ipynb
+++ b/tasks/task_10_activation_transmutation_depletion/5_full_pulse_schedule.ipynb
@@ -193,14 +193,7 @@
    "id": "289778c1-f4e2-47d0-a677-b2e528ac2ed9",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "flux_in_each_group, micro_xs = openmc.deplete.get_microxs_and_flux(\n",
-    "    model=model,\n",
-    "    domains=[shield_cell],\n",
-    "    energies=[0, 30e6], # one energy bin from 0 to 30MeV\n",
-    "    chain_file=openmc.config['chain_file'],\n",
-    ")"
-   ]
+   "source": "flux_in_each_group, micro_xs = openmc.deplete.get_microxs_and_flux(\n    model=model,\n    domains=[shield_cell],\n    chain_file=openmc.config['chain_file'],\n)"
   },
   {
    "cell_type": "markdown",

--- a/tasks/task_20_CAD_shut_down_dose_rate/1_unstructured_mesh_R2S_shutdown_dose_rate.ipynb
+++ b/tasks/task_20_CAD_shut_down_dose_rate/1_unstructured_mesh_R2S_shutdown_dose_rate.ipynb
@@ -239,17 +239,7 @@
    "id": "d119240c",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "flux_in_each_voxel, micro_xs = openmc.deplete.get_microxs_and_flux(\n",
-    "    model=model,\n",
-    "    domains=umesh,\n",
-    "    energies=[0, 30e6], # one energy bin from 0 to 30MeV\n",
-    "    chain_file=openmc.config['chain_file'],\n",
-    "    # needed otherwise the statepoint file is produced in an unknown temporary directory\n",
-    "    run_kwargs={'cwd':'.'},\n",
-    "    nuclides=my_material.get_nuclides()\n",
-    ")\n"
-   ]
+   "source": "flux_in_each_voxel, micro_xs = openmc.deplete.get_microxs_and_flux(\n    model=model,\n    domains=umesh,\n    chain_file=openmc.config['chain_file'],\n    # needed otherwise the statepoint file is produced in an unknown temporary directory\n    run_kwargs={'cwd':'.'},\n    nuclides=my_material.get_nuclides()\n)\n"
   },
   {
    "cell_type": "markdown",

--- a/tasks/task_20_CAD_shut_down_dose_rate/2_unstructured_mesh_R2S_shutdown_dose_rate_several_materials.ipynb
+++ b/tasks/task_20_CAD_shut_down_dose_rate/2_unstructured_mesh_R2S_shutdown_dose_rate_several_materials.ipynb
@@ -252,23 +252,7 @@
    "id": "d119240c",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "all_nuclides = set()\n",
-    "for material in my_materials:\n",
-    "    all_nuclides.update(material.get_nuclides())\n",
-    "\n",
-    "! rm statepoint.5.h5\n",
-    "\n",
-    "flux_in_each_voxel, micro_xs = openmc.deplete.get_microxs_and_flux(\n",
-    "    model=model,\n",
-    "    domains=umesh,\n",
-    "    energies=[0, 30e6], # one energy bin from 0 to 30MeV\n",
-    "    chain_file=openmc.config['chain_file'],\n",
-    "    # needed otherwise the statepoint file is produced in an unknown temporary directory\n",
-    "    run_kwargs={'cwd':'.'},\n",
-    "    nuclides=list(all_nuclides)  # Convert set to list\n",
-    ")"
-   ]
+   "source": "all_nuclides = set()\nfor material in my_materials:\n    all_nuclides.update(material.get_nuclides())\n\n! rm statepoint.5.h5\n\nflux_in_each_voxel, micro_xs = openmc.deplete.get_microxs_and_flux(\n    model=model,\n    domains=umesh,\n    chain_file=openmc.config['chain_file'],\n    # needed otherwise the statepoint file is produced in an unknown temporary directory\n    run_kwargs={'cwd':'.'},\n    nuclides=list(all_nuclides)  # Convert set to list\n)"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
thanks to this PR https://github.com/openmc-dev/openmc/pull/3977
and a rebuild of the wheels here https://github.com/shimwell/wheels
we can remove the energies arg from the function :tada:

a lot of work for a tiny simplification but every one helps