### PR TITLE
Add forward vs adjoint flux comparison to FW-CADIS task

### DIFF
--- a/tasks/full-day-workshop/task_17/task_17.ipynb
+++ b/tasks/full-day-workshop/task_17/task_17.ipynb
@@ -33,7 +33,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3448d1db-4328-42e3-8960-50d53896f541",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:11.424000Z",
+     "iopub.status.busy": "2026-07-01T09:20:11.423722Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.141623Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.140851Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import copy\n",
@@ -61,7 +68,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "47cb21c7-0afa-446c-9a6b-76c8dfb2f93e",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.143998Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.143833Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.161557Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.161046Z"
+    }
+   },
    "outputs": [],
    "source": [
     "mat_air = openmc.Material(name=\"air\")\n",
@@ -99,7 +113,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a72dc5e3-cb8e-41c2-9cfb-f8f7489c7f44",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.164196Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.164114Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.170652Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.169864Z"
+    }
+   },
    "outputs": [],
    "source": [
     "width_a = 100\n",
@@ -209,7 +230,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "94c41f17",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.172471Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.172393Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.353045Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.352699Z"
+    }
+   },
    "outputs": [],
    "source": [
     "plot = geometry.plot(basis='xy',  color_by='material')\n",
@@ -229,7 +257,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fd4986b0",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.354391Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.354295Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.356664Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.356254Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# location of the point source\n",
@@ -259,7 +294,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0731aba5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.358060Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.357977Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.361114Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.360653Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Create settings\n",
@@ -294,7 +336,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "42c62be1",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.362063Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.361980Z",
+     "iopub.status.idle": "2026-07-01T09:20:40.047285Z",
+     "shell.execute_reply": "2026-07-01T09:20:40.045164Z"
+    }
+   },
    "outputs": [],
    "source": [
     "rr_model = copy.deepcopy(ce_model)\n",
@@ -330,7 +379,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "200913a2",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:40.051640Z",
+     "iopub.status.busy": "2026-07-01T09:20:40.051399Z",
+     "iopub.status.idle": "2026-07-01T09:20:40.063895Z",
+     "shell.execute_reply": "2026-07-01T09:20:40.062779Z"
+    }
+   },
    "outputs": [],
    "source": [
     "rr_model.convert_to_random_ray()"
@@ -359,7 +415,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9d7bbee6",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:40.066551Z",
+     "iopub.status.busy": "2026-07-01T09:20:40.066357Z",
+     "iopub.status.idle": "2026-07-01T09:20:40.091297Z",
+     "shell.execute_reply": "2026-07-01T09:20:40.090301Z"
+    }
+   },
    "outputs": [],
    "source": [
     "mesh = openmc.RegularMesh().from_domain(geometry)\n",
@@ -375,7 +438,12 @@
     "tallies = openmc.Tallies([flux_tally])\n",
     "\n",
     "# 2. Subdivide random ray source regions\n",
-    "rr_model.settings.random_ray['source_region_meshes'] = [(mesh, [rr_model.geometry.root_universe])]"
+    "rr_model.settings.random_ray['source_region_meshes'] = [(mesh, [rr_model.geometry.root_universe])]\n",
+    "\n",
+    "# Attach the tally to the random ray model so that BOTH the forward solve\n",
+    "# and the adjoint solve record it. The forward solve is saved to\n",
+    "# statepoint.forward.<batch>.h5, letting us compare both fluxes below.\n",
+    "rr_model.tallies = tallies"
    ]
   },
   {
@@ -407,7 +475,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ca0db814",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:40.094647Z",
+     "iopub.status.busy": "2026-07-01T09:20:40.094462Z",
+     "iopub.status.idle": "2026-07-01T09:20:40.097787Z",
+     "shell.execute_reply": "2026-07-01T09:20:40.096875Z"
+    }
+   },
    "outputs": [],
    "source": [
     "rr_model.settings.weight_window_generators = openmc.WeightWindowGenerator(\n",
@@ -428,7 +503,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "51193faf",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:40.100581Z",
+     "iopub.status.busy": "2026-07-01T09:20:40.100400Z",
+     "iopub.status.idle": "2026-07-01T09:21:00.629973Z",
+     "shell.execute_reply": "2026-07-01T09:21:00.628915Z"
+    }
+   },
    "outputs": [],
    "source": [
     "random_ray_wwg_statepoint = rr_model.run()"
@@ -436,10 +518,96 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c85db7ae",
+   "id": "c2588036",
    "metadata": {},
    "source": [
-    "Plot the **ADJOINT** flux. Not necessary, but interesting to see how they compare to the forward flux solve."
+    "# Compare the Forward and Adjoint Flux\n",
+    "\n",
+    "The FW-CADIS `run()` above actually performed **two** solves back to back:\n",
+    "\n",
+    "1. a **forward** solve, giving the physical neutron flux streaming out from the source, and\n",
+    "2. an **adjoint** solve, giving the *importance* function, i.e. how much a neutron at each\n",
+    "   location matters for getting good statistics everywhere in the problem.\n",
+    "\n",
+    "The adjoint source used in step 2 is built directly from the forward flux of step 1. That\n",
+    "coupling is what the **FW** (forward-weighted) in FW-CADIS refers to, and it is why the random\n",
+    "ray solver runs a forward pass before the adjoint pass. The weight windows we use later are\n",
+    "derived from this adjoint flux.\n",
+    "\n",
+    "The forward solve writes `statepoint.forward.<batch>.h5` (and `tallies.forward.out`) while the\n",
+    "adjoint solve keeps the usual `statepoint.<batch>.h5`, so a single run gives us both fluxes to\n",
+    "load and compare.\n",
+    "\n",
+    "Plotting them side by side is the clearest way to build intuition for why variance reduction\n",
+    "is needed and what it does:\n",
+    "\n",
+    "* The **forward flux** is bright near the source and falls by many orders of magnitude through\n",
+    "  each concrete wall. This is exactly why an unbiased (analog) simulation starves the\n",
+    "  deep-shield and corridor regions of particles, and why the *weight windows off* error map\n",
+    "  further down blows up in those regions.\n",
+    "* The **adjoint flux** is elevated in those same hard-to-reach regions, because that is where a\n",
+    "  neutron is most valuable for achieving uniform global statistics. The weight windows\n",
+    "  (roughly proportional to 1/adjoint) then encourage particle splitting into exactly those\n",
+    "  regions.\n",
+    "\n",
+    "Notice the two fields live on very different scales, so each panel uses its own colour bar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "167b74ea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:00.632565Z",
+     "iopub.status.busy": "2026-07-01T09:21:00.632308Z",
+     "iopub.status.idle": "2026-07-01T09:21:04.456705Z",
+     "shell.execute_reply": "2026-07-01T09:21:04.456130Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# The forward solve statepoint is named with a 'forward' infix and lives at the final batch.\n",
+    "forward_statepoint = f'statepoint.forward.{rr_model.settings.batches}.h5'\n",
+    "\n",
+    "\n",
+    "def get_mesh_flux(statepoint_file):\n",
+    "    with openmc.StatePoint(statepoint_file) as sp:\n",
+    "        tally = sp.get_tally(name='flux tally')\n",
+    "    return tally.get_reshaped_data(value='mean', expand_dims=True).squeeze()\n",
+    "\n",
+    "\n",
+    "forward_flux = get_mesh_flux(forward_statepoint)\n",
+    "adjoint_flux = get_mesh_flux(random_ray_wwg_statepoint)  # the adjoint solve statepoint\n",
+    "\n",
+    "mesh_extent = mesh.bounding_box.extent['xy']\n",
+    "\n",
+    "fig, (ax_fwd, ax_adj) = plt.subplots(ncols=2, figsize=(12, 5))\n",
+    "\n",
+    "for ax, data, title in [\n",
+    "    (ax_fwd, forward_flux, 'Forward flux (where neutrons actually go)'),\n",
+    "    (ax_adj, adjoint_flux, 'Adjoint flux (neutron importance)'),\n",
+    "]:\n",
+    "    im = ax.imshow(\n",
+    "        data.T,\n",
+    "        origin='lower',\n",
+    "        extent=mesh_extent,\n",
+    "        norm=LogNorm(),\n",
+    "    )\n",
+    "    plt.colorbar(im, ax=ax, fraction=0.046, pad=0.04)\n",
+    "    # overlay the geometry outline so the walls, room and corridor are visible\n",
+    "    ce_model.plot(\n",
+    "        outline='only',\n",
+    "        extent=ce_model.bounding_box.extent['xy'],\n",
+    "        axes=ax,\n",
+    "        pixels=10_000_000,  # avoids rounded corners on outline\n",
+    "        color_by='material',\n",
+    "    )\n",
+    "    ax.set_title(title)\n",
+    "\n",
+    "fig.suptitle('FW-CADIS: forward flux vs adjoint (importance) flux from a single run')\n",
+    "plt.tight_layout()\n",
+    "plt.savefig('forward_vs_adjoint_flux.png', bbox_inches='tight')"
    ]
   },
   {
@@ -454,7 +622,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9005a35c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:04.458827Z",
+     "iopub.status.busy": "2026-07-01T09:21:04.458726Z",
+     "iopub.status.idle": "2026-07-01T09:21:04.616437Z",
+     "shell.execute_reply": "2026-07-01T09:21:04.614944Z"
+    }
+   },
    "outputs": [],
    "source": [
     "!ls -lh weight_windows.h5"
@@ -473,7 +648,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fef2f2ce",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:04.619387Z",
+     "iopub.status.busy": "2026-07-01T09:21:04.619138Z",
+     "iopub.status.idle": "2026-07-01T09:21:06.131637Z",
+     "shell.execute_reply": "2026-07-01T09:21:06.131120Z"
+    }
+   },
    "outputs": [],
    "source": [
     "weight_windows = openmc.hdf5_to_wws('weight_windows.h5')\n",
@@ -512,7 +694,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "70741ea5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:06.134410Z",
+     "iopub.status.busy": "2026-07-01T09:21:06.134290Z",
+     "iopub.status.idle": "2026-07-01T09:21:06.137038Z",
+     "shell.execute_reply": "2026-07-01T09:21:06.136407Z"
+    }
+   },
    "outputs": [],
    "source": [
     "settings = openmc.Settings()\n",
@@ -540,7 +729,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f46685d0",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:06.138664Z",
+     "iopub.status.busy": "2026-07-01T09:21:06.138467Z",
+     "iopub.status.idle": "2026-07-01T09:21:06.149887Z",
+     "shell.execute_reply": "2026-07-01T09:21:06.149295Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -560,7 +756,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a9cb47af",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:06.151842Z",
+     "iopub.status.busy": "2026-07-01T09:21:06.151685Z",
+     "iopub.status.idle": "2026-07-01T09:21:06.155733Z",
+     "shell.execute_reply": "2026-07-01T09:21:06.155275Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def run_and_plot(model: openmc.Model, image_filename: str) -> openmc.StatePoint:\n",
@@ -620,7 +823,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "21e2fcf8",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:06.157265Z",
+     "iopub.status.busy": "2026-07-01T09:21:06.157173Z",
+     "iopub.status.idle": "2026-07-01T09:21:27.311143Z",
+     "shell.execute_reply": "2026-07-01T09:21:27.310405Z"
+    }
+   },
    "outputs": [],
    "source": [
     "run_and_plot(simulation_using_ww_off, \"no_fw_cadis.png\")"
@@ -650,7 +860,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a7791bcf",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:27.313337Z",
+     "iopub.status.busy": "2026-07-01T09:21:27.313232Z",
+     "iopub.status.idle": "2026-07-01T09:21:27.315621Z",
+     "shell.execute_reply": "2026-07-01T09:21:27.315107Z"
+    }
+   },
    "outputs": [],
    "source": [
     "settings.weight_windows_on = True # Now, turn on the FW-CADIS generated weight windows\n",
@@ -662,7 +879,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "619f2dce",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:27.316561Z",
+     "iopub.status.busy": "2026-07-01T09:21:27.316467Z",
+     "iopub.status.idle": "2026-07-01T09:21:42.055358Z",
+     "shell.execute_reply": "2026-07-01T09:21:42.054360Z"
+    }
+   },
    "outputs": [],
    "source": [
     "run_and_plot(simulation_using_ww_on, \"fw_cadis.png\")"
@@ -671,7 +895,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".neutronicsworkshop_3.12",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -685,7 +909,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,

--- a/tasks/half-day-conference-workshop/task_10/task_10.ipynb
+++ b/tasks/half-day-conference-workshop/task_10/task_10.ipynb
@@ -33,7 +33,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3448d1db-4328-42e3-8960-50d53896f541",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:11.424000Z",
+     "iopub.status.busy": "2026-07-01T09:20:11.423722Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.141623Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.140851Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import copy\n",
@@ -61,7 +68,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "47cb21c7-0afa-446c-9a6b-76c8dfb2f93e",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.143998Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.143833Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.161557Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.161046Z"
+    }
+   },
    "outputs": [],
    "source": [
     "mat_air = openmc.Material(name=\"air\")\n",
@@ -99,7 +113,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a72dc5e3-cb8e-41c2-9cfb-f8f7489c7f44",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.164196Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.164114Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.170652Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.169864Z"
+    }
+   },
    "outputs": [],
    "source": [
     "width_a = 100\n",
@@ -209,7 +230,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "94c41f17",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.172471Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.172393Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.353045Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.352699Z"
+    }
+   },
    "outputs": [],
    "source": [
     "plot = geometry.plot(basis='xy',  color_by='material')\n",
@@ -229,7 +257,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fd4986b0",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.354391Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.354295Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.356664Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.356254Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# location of the point source\n",
@@ -259,7 +294,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0731aba5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.358060Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.357977Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.361114Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.360653Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Create settings\n",
@@ -294,7 +336,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "42c62be1",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.362063Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.361980Z",
+     "iopub.status.idle": "2026-07-01T09:20:40.047285Z",
+     "shell.execute_reply": "2026-07-01T09:20:40.045164Z"
+    }
+   },
    "outputs": [],
    "source": [
     "rr_model = copy.deepcopy(ce_model)\n",
@@ -330,7 +379,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "200913a2",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:40.051640Z",
+     "iopub.status.busy": "2026-07-01T09:20:40.051399Z",
+     "iopub.status.idle": "2026-07-01T09:20:40.063895Z",
+     "shell.execute_reply": "2026-07-01T09:20:40.062779Z"
+    }
+   },
    "outputs": [],
    "source": [
     "rr_model.convert_to_random_ray()"
@@ -359,7 +415,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9d7bbee6",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:40.066551Z",
+     "iopub.status.busy": "2026-07-01T09:20:40.066357Z",
+     "iopub.status.idle": "2026-07-01T09:20:40.091297Z",
+     "shell.execute_reply": "2026-07-01T09:20:40.090301Z"
+    }
+   },
    "outputs": [],
    "source": [
     "mesh = openmc.RegularMesh().from_domain(geometry)\n",
@@ -375,7 +438,12 @@
     "tallies = openmc.Tallies([flux_tally])\n",
     "\n",
     "# 2. Subdivide random ray source regions\n",
-    "rr_model.settings.random_ray['source_region_meshes'] = [(mesh, [rr_model.geometry.root_universe])]"
+    "rr_model.settings.random_ray['source_region_meshes'] = [(mesh, [rr_model.geometry.root_universe])]\n",
+    "\n",
+    "# Attach the tally to the random ray model so that BOTH the forward solve\n",
+    "# and the adjoint solve record it. The forward solve is saved to\n",
+    "# statepoint.forward.<batch>.h5, letting us compare both fluxes below.\n",
+    "rr_model.tallies = tallies"
    ]
   },
   {
@@ -407,7 +475,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ca0db814",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:40.094647Z",
+     "iopub.status.busy": "2026-07-01T09:20:40.094462Z",
+     "iopub.status.idle": "2026-07-01T09:20:40.097787Z",
+     "shell.execute_reply": "2026-07-01T09:20:40.096875Z"
+    }
+   },
    "outputs": [],
    "source": [
     "rr_model.settings.weight_window_generators = openmc.WeightWindowGenerator(\n",
@@ -428,7 +503,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "51193faf",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:40.100581Z",
+     "iopub.status.busy": "2026-07-01T09:20:40.100400Z",
+     "iopub.status.idle": "2026-07-01T09:21:00.629973Z",
+     "shell.execute_reply": "2026-07-01T09:21:00.628915Z"
+    }
+   },
    "outputs": [],
    "source": [
     "random_ray_wwg_statepoint = rr_model.run()"
@@ -436,10 +518,96 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c85db7ae",
+   "id": "c2588036",
    "metadata": {},
    "source": [
-    "Plot the **ADJOINT** flux. Not necessary, but interesting to see how they compare to the forward flux solve."
+    "# Compare the Forward and Adjoint Flux\n",
+    "\n",
+    "The FW-CADIS `run()` above actually performed **two** solves back to back:\n",
+    "\n",
+    "1. a **forward** solve, giving the physical neutron flux streaming out from the source, and\n",
+    "2. an **adjoint** solve, giving the *importance* function, i.e. how much a neutron at each\n",
+    "   location matters for getting good statistics everywhere in the problem.\n",
+    "\n",
+    "The adjoint source used in step 2 is built directly from the forward flux of step 1. That\n",
+    "coupling is what the **FW** (forward-weighted) in FW-CADIS refers to, and it is why the random\n",
+    "ray solver runs a forward pass before the adjoint pass. The weight windows we use later are\n",
+    "derived from this adjoint flux.\n",
+    "\n",
+    "The forward solve writes `statepoint.forward.<batch>.h5` (and `tallies.forward.out`) while the\n",
+    "adjoint solve keeps the usual `statepoint.<batch>.h5`, so a single run gives us both fluxes to\n",
+    "load and compare.\n",
+    "\n",
+    "Plotting them side by side is the clearest way to build intuition for why variance reduction\n",
+    "is needed and what it does:\n",
+    "\n",
+    "* The **forward flux** is bright near the source and falls by many orders of magnitude through\n",
+    "  each concrete wall. This is exactly why an unbiased (analog) simulation starves the\n",
+    "  deep-shield and corridor regions of particles, and why the *weight windows off* error map\n",
+    "  further down blows up in those regions.\n",
+    "* The **adjoint flux** is elevated in those same hard-to-reach regions, because that is where a\n",
+    "  neutron is most valuable for achieving uniform global statistics. The weight windows\n",
+    "  (roughly proportional to 1/adjoint) then encourage particle splitting into exactly those\n",
+    "  regions.\n",
+    "\n",
+    "Notice the two fields live on very different scales, so each panel uses its own colour bar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "167b74ea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:00.632565Z",
+     "iopub.status.busy": "2026-07-01T09:21:00.632308Z",
+     "iopub.status.idle": "2026-07-01T09:21:04.456705Z",
+     "shell.execute_reply": "2026-07-01T09:21:04.456130Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# The forward solve statepoint is named with a 'forward' infix and lives at the final batch.\n",
+    "forward_statepoint = f'statepoint.forward.{rr_model.settings.batches}.h5'\n",
+    "\n",
+    "\n",
+    "def get_mesh_flux(statepoint_file):\n",
+    "    with openmc.StatePoint(statepoint_file) as sp:\n",
+    "        tally = sp.get_tally(name='flux tally')\n",
+    "    return tally.get_reshaped_data(value='mean', expand_dims=True).squeeze()\n",
+    "\n",
+    "\n",
+    "forward_flux = get_mesh_flux(forward_statepoint)\n",
+    "adjoint_flux = get_mesh_flux(random_ray_wwg_statepoint)  # the adjoint solve statepoint\n",
+    "\n",
+    "mesh_extent = mesh.bounding_box.extent['xy']\n",
+    "\n",
+    "fig, (ax_fwd, ax_adj) = plt.subplots(ncols=2, figsize=(12, 5))\n",
+    "\n",
+    "for ax, data, title in [\n",
+    "    (ax_fwd, forward_flux, 'Forward flux (where neutrons actually go)'),\n",
+    "    (ax_adj, adjoint_flux, 'Adjoint flux (neutron importance)'),\n",
+    "]:\n",
+    "    im = ax.imshow(\n",
+    "        data.T,\n",
+    "        origin='lower',\n",
+    "        extent=mesh_extent,\n",
+    "        norm=LogNorm(),\n",
+    "    )\n",
+    "    plt.colorbar(im, ax=ax, fraction=0.046, pad=0.04)\n",
+    "    # overlay the geometry outline so the walls, room and corridor are visible\n",
+    "    ce_model.plot(\n",
+    "        outline='only',\n",
+    "        extent=ce_model.bounding_box.extent['xy'],\n",
+    "        axes=ax,\n",
+    "        pixels=10_000_000,  # avoids rounded corners on outline\n",
+    "        color_by='material',\n",
+    "    )\n",
+    "    ax.set_title(title)\n",
+    "\n",
+    "fig.suptitle('FW-CADIS: forward flux vs adjoint (importance) flux from a single run')\n",
+    "plt.tight_layout()\n",
+    "plt.savefig('forward_vs_adjoint_flux.png', bbox_inches='tight')"
    ]
   },
   {
@@ -454,7 +622,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9005a35c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:04.458827Z",
+     "iopub.status.busy": "2026-07-01T09:21:04.458726Z",
+     "iopub.status.idle": "2026-07-01T09:21:04.616437Z",
+     "shell.execute_reply": "2026-07-01T09:21:04.614944Z"
+    }
+   },
    "outputs": [],
    "source": [
     "!ls -lh weight_windows.h5"
@@ -473,7 +648,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fef2f2ce",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:04.619387Z",
+     "iopub.status.busy": "2026-07-01T09:21:04.619138Z",
+     "iopub.status.idle": "2026-07-01T09:21:06.131637Z",
+     "shell.execute_reply": "2026-07-01T09:21:06.131120Z"
+    }
+   },
    "outputs": [],
    "source": [
     "weight_windows = openmc.hdf5_to_wws('weight_windows.h5')\n",
@@ -512,7 +694,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "70741ea5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:06.134410Z",
+     "iopub.status.busy": "2026-07-01T09:21:06.134290Z",
+     "iopub.status.idle": "2026-07-01T09:21:06.137038Z",
+     "shell.execute_reply": "2026-07-01T09:21:06.136407Z"
+    }
+   },
    "outputs": [],
    "source": [
     "settings = openmc.Settings()\n",
@@ -540,7 +729,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f46685d0",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:06.138664Z",
+     "iopub.status.busy": "2026-07-01T09:21:06.138467Z",
+     "iopub.status.idle": "2026-07-01T09:21:06.149887Z",
+     "shell.execute_reply": "2026-07-01T09:21:06.149295Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -560,7 +756,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a9cb47af",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:06.151842Z",
+     "iopub.status.busy": "2026-07-01T09:21:06.151685Z",
+     "iopub.status.idle": "2026-07-01T09:21:06.155733Z",
+     "shell.execute_reply": "2026-07-01T09:21:06.155275Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def run_and_plot(model: openmc.Model, image_filename: str) -> openmc.StatePoint:\n",
@@ -620,7 +823,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "21e2fcf8",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:06.157265Z",
+     "iopub.status.busy": "2026-07-01T09:21:06.157173Z",
+     "iopub.status.idle": "2026-07-01T09:21:27.311143Z",
+     "shell.execute_reply": "2026-07-01T09:21:27.310405Z"
+    }
+   },
    "outputs": [],
    "source": [
     "run_and_plot(simulation_using_ww_off, \"no_fw_cadis.png\")"
@@ -650,7 +860,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a7791bcf",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:27.313337Z",
+     "iopub.status.busy": "2026-07-01T09:21:27.313232Z",
+     "iopub.status.idle": "2026-07-01T09:21:27.315621Z",
+     "shell.execute_reply": "2026-07-01T09:21:27.315107Z"
+    }
+   },
    "outputs": [],
    "source": [
     "settings.weight_windows_on = True # Now, turn on the FW-CADIS generated weight windows\n",
@@ -662,7 +879,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "619f2dce",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:27.316561Z",
+     "iopub.status.busy": "2026-07-01T09:21:27.316467Z",
+     "iopub.status.idle": "2026-07-01T09:21:42.055358Z",
+     "shell.execute_reply": "2026-07-01T09:21:42.054360Z"
+    }
+   },
    "outputs": [],
    "source": [
     "run_and_plot(simulation_using_ww_on, \"fw_cadis.png\")"
@@ -671,7 +895,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".neutronicsworkshop_3.12",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -685,7 +909,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,

--- a/tasks/task_14_variance_reduction/5_shielded_room_fw_cadis.ipynb
+++ b/tasks/task_14_variance_reduction/5_shielded_room_fw_cadis.ipynb
@@ -33,7 +33,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3448d1db-4328-42e3-8960-50d53896f541",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:11.424000Z",
+     "iopub.status.busy": "2026-07-01T09:20:11.423722Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.141623Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.140851Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import copy\n",
@@ -61,7 +68,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "47cb21c7-0afa-446c-9a6b-76c8dfb2f93e",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.143998Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.143833Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.161557Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.161046Z"
+    }
+   },
    "outputs": [],
    "source": [
     "mat_air = openmc.Material(name=\"air\")\n",
@@ -99,7 +113,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a72dc5e3-cb8e-41c2-9cfb-f8f7489c7f44",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.164196Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.164114Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.170652Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.169864Z"
+    }
+   },
    "outputs": [],
    "source": [
     "width_a = 100\n",
@@ -209,7 +230,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "94c41f17",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.172471Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.172393Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.353045Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.352699Z"
+    }
+   },
    "outputs": [],
    "source": [
     "plot = geometry.plot(basis='xy',  color_by='material')\n",
@@ -229,7 +257,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fd4986b0",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.354391Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.354295Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.356664Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.356254Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# location of the point source\n",
@@ -259,7 +294,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0731aba5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.358060Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.357977Z",
+     "iopub.status.idle": "2026-07-01T09:20:12.361114Z",
+     "shell.execute_reply": "2026-07-01T09:20:12.360653Z"
+    }
+   },
    "outputs": [],
    "source": [
     "# Create settings\n",
@@ -294,7 +336,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "42c62be1",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:12.362063Z",
+     "iopub.status.busy": "2026-07-01T09:20:12.361980Z",
+     "iopub.status.idle": "2026-07-01T09:20:40.047285Z",
+     "shell.execute_reply": "2026-07-01T09:20:40.045164Z"
+    }
+   },
    "outputs": [],
    "source": [
     "rr_model = copy.deepcopy(ce_model)\n",
@@ -330,7 +379,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "200913a2",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:40.051640Z",
+     "iopub.status.busy": "2026-07-01T09:20:40.051399Z",
+     "iopub.status.idle": "2026-07-01T09:20:40.063895Z",
+     "shell.execute_reply": "2026-07-01T09:20:40.062779Z"
+    }
+   },
    "outputs": [],
    "source": [
     "rr_model.convert_to_random_ray()"
@@ -359,7 +415,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9d7bbee6",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:40.066551Z",
+     "iopub.status.busy": "2026-07-01T09:20:40.066357Z",
+     "iopub.status.idle": "2026-07-01T09:20:40.091297Z",
+     "shell.execute_reply": "2026-07-01T09:20:40.090301Z"
+    }
+   },
    "outputs": [],
    "source": [
     "mesh = openmc.RegularMesh().from_domain(geometry)\n",
@@ -375,7 +438,12 @@
     "tallies = openmc.Tallies([flux_tally])\n",
     "\n",
     "# 2. Subdivide random ray source regions\n",
-    "rr_model.settings.random_ray['source_region_meshes'] = [(mesh, [rr_model.geometry.root_universe])]"
+    "rr_model.settings.random_ray['source_region_meshes'] = [(mesh, [rr_model.geometry.root_universe])]\n",
+    "\n",
+    "# Attach the tally to the random ray model so that BOTH the forward solve\n",
+    "# and the adjoint solve record it. The forward solve is saved to\n",
+    "# statepoint.forward.<batch>.h5, letting us compare both fluxes below.\n",
+    "rr_model.tallies = tallies"
    ]
   },
   {
@@ -407,7 +475,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ca0db814",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:40.094647Z",
+     "iopub.status.busy": "2026-07-01T09:20:40.094462Z",
+     "iopub.status.idle": "2026-07-01T09:20:40.097787Z",
+     "shell.execute_reply": "2026-07-01T09:20:40.096875Z"
+    }
+   },
    "outputs": [],
    "source": [
     "rr_model.settings.weight_window_generators = openmc.WeightWindowGenerator(\n",
@@ -428,7 +503,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "51193faf",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:20:40.100581Z",
+     "iopub.status.busy": "2026-07-01T09:20:40.100400Z",
+     "iopub.status.idle": "2026-07-01T09:21:00.629973Z",
+     "shell.execute_reply": "2026-07-01T09:21:00.628915Z"
+    }
+   },
    "outputs": [],
    "source": [
     "random_ray_wwg_statepoint = rr_model.run()"
@@ -436,10 +518,96 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c85db7ae",
+   "id": "c2588036",
    "metadata": {},
    "source": [
-    "Plot the **ADJOINT** flux. Not necessary, but interesting to see how they compare to the forward flux solve."
+    "# Compare the Forward and Adjoint Flux\n",
+    "\n",
+    "The FW-CADIS `run()` above actually performed **two** solves back to back:\n",
+    "\n",
+    "1. a **forward** solve, giving the physical neutron flux streaming out from the source, and\n",
+    "2. an **adjoint** solve, giving the *importance* function, i.e. how much a neutron at each\n",
+    "   location matters for getting good statistics everywhere in the problem.\n",
+    "\n",
+    "The adjoint source used in step 2 is built directly from the forward flux of step 1. That\n",
+    "coupling is what the **FW** (forward-weighted) in FW-CADIS refers to, and it is why the random\n",
+    "ray solver runs a forward pass before the adjoint pass. The weight windows we use later are\n",
+    "derived from this adjoint flux.\n",
+    "\n",
+    "The forward solve writes `statepoint.forward.<batch>.h5` (and `tallies.forward.out`) while the\n",
+    "adjoint solve keeps the usual `statepoint.<batch>.h5`, so a single run gives us both fluxes to\n",
+    "load and compare.\n",
+    "\n",
+    "Plotting them side by side is the clearest way to build intuition for why variance reduction\n",
+    "is needed and what it does:\n",
+    "\n",
+    "* The **forward flux** is bright near the source and falls by many orders of magnitude through\n",
+    "  each concrete wall. This is exactly why an unbiased (analog) simulation starves the\n",
+    "  deep-shield and corridor regions of particles, and why the *weight windows off* error map\n",
+    "  further down blows up in those regions.\n",
+    "* The **adjoint flux** is elevated in those same hard-to-reach regions, because that is where a\n",
+    "  neutron is most valuable for achieving uniform global statistics. The weight windows\n",
+    "  (roughly proportional to 1/adjoint) then encourage particle splitting into exactly those\n",
+    "  regions.\n",
+    "\n",
+    "Notice the two fields live on very different scales, so each panel uses its own colour bar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "167b74ea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:00.632565Z",
+     "iopub.status.busy": "2026-07-01T09:21:00.632308Z",
+     "iopub.status.idle": "2026-07-01T09:21:04.456705Z",
+     "shell.execute_reply": "2026-07-01T09:21:04.456130Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# The forward solve statepoint is named with a 'forward' infix and lives at the final batch.\n",
+    "forward_statepoint = f'statepoint.forward.{rr_model.settings.batches}.h5'\n",
+    "\n",
+    "\n",
+    "def get_mesh_flux(statepoint_file):\n",
+    "    with openmc.StatePoint(statepoint_file) as sp:\n",
+    "        tally = sp.get_tally(name='flux tally')\n",
+    "    return tally.get_reshaped_data(value='mean', expand_dims=True).squeeze()\n",
+    "\n",
+    "\n",
+    "forward_flux = get_mesh_flux(forward_statepoint)\n",
+    "adjoint_flux = get_mesh_flux(random_ray_wwg_statepoint)  # the adjoint solve statepoint\n",
+    "\n",
+    "mesh_extent = mesh.bounding_box.extent['xy']\n",
+    "\n",
+    "fig, (ax_fwd, ax_adj) = plt.subplots(ncols=2, figsize=(12, 5))\n",
+    "\n",
+    "for ax, data, title in [\n",
+    "    (ax_fwd, forward_flux, 'Forward flux (where neutrons actually go)'),\n",
+    "    (ax_adj, adjoint_flux, 'Adjoint flux (neutron importance)'),\n",
+    "]:\n",
+    "    im = ax.imshow(\n",
+    "        data.T,\n",
+    "        origin='lower',\n",
+    "        extent=mesh_extent,\n",
+    "        norm=LogNorm(),\n",
+    "    )\n",
+    "    plt.colorbar(im, ax=ax, fraction=0.046, pad=0.04)\n",
+    "    # overlay the geometry outline so the walls, room and corridor are visible\n",
+    "    ce_model.plot(\n",
+    "        outline='only',\n",
+    "        extent=ce_model.bounding_box.extent['xy'],\n",
+    "        axes=ax,\n",
+    "        pixels=10_000_000,  # avoids rounded corners on outline\n",
+    "        color_by='material',\n",
+    "    )\n",
+    "    ax.set_title(title)\n",
+    "\n",
+    "fig.suptitle('FW-CADIS: forward flux vs adjoint (importance) flux from a single run')\n",
+    "plt.tight_layout()\n",
+    "plt.savefig('forward_vs_adjoint_flux.png', bbox_inches='tight')"
    ]
   },
   {
@@ -454,7 +622,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9005a35c",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:04.458827Z",
+     "iopub.status.busy": "2026-07-01T09:21:04.458726Z",
+     "iopub.status.idle": "2026-07-01T09:21:04.616437Z",
+     "shell.execute_reply": "2026-07-01T09:21:04.614944Z"
+    }
+   },
    "outputs": [],
    "source": [
     "!ls -lh weight_windows.h5"
@@ -473,7 +648,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fef2f2ce",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:04.619387Z",
+     "iopub.status.busy": "2026-07-01T09:21:04.619138Z",
+     "iopub.status.idle": "2026-07-01T09:21:06.131637Z",
+     "shell.execute_reply": "2026-07-01T09:21:06.131120Z"
+    }
+   },
    "outputs": [],
    "source": [
     "weight_windows = openmc.hdf5_to_wws('weight_windows.h5')\n",
@@ -512,7 +694,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "70741ea5",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:06.134410Z",
+     "iopub.status.busy": "2026-07-01T09:21:06.134290Z",
+     "iopub.status.idle": "2026-07-01T09:21:06.137038Z",
+     "shell.execute_reply": "2026-07-01T09:21:06.136407Z"
+    }
+   },
    "outputs": [],
    "source": [
     "settings = openmc.Settings()\n",
@@ -540,7 +729,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f46685d0",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:06.138664Z",
+     "iopub.status.busy": "2026-07-01T09:21:06.138467Z",
+     "iopub.status.idle": "2026-07-01T09:21:06.149887Z",
+     "shell.execute_reply": "2026-07-01T09:21:06.149295Z"
+    }
+   },
    "outputs": [],
    "source": [
     "\n",
@@ -560,7 +756,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a9cb47af",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:06.151842Z",
+     "iopub.status.busy": "2026-07-01T09:21:06.151685Z",
+     "iopub.status.idle": "2026-07-01T09:21:06.155733Z",
+     "shell.execute_reply": "2026-07-01T09:21:06.155275Z"
+    }
+   },
    "outputs": [],
    "source": [
     "def run_and_plot(model: openmc.Model, image_filename: str) -> openmc.StatePoint:\n",
@@ -620,7 +823,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "21e2fcf8",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:06.157265Z",
+     "iopub.status.busy": "2026-07-01T09:21:06.157173Z",
+     "iopub.status.idle": "2026-07-01T09:21:27.311143Z",
+     "shell.execute_reply": "2026-07-01T09:21:27.310405Z"
+    }
+   },
    "outputs": [],
    "source": [
     "run_and_plot(simulation_using_ww_off, \"no_fw_cadis.png\")"
@@ -650,7 +860,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a7791bcf",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:27.313337Z",
+     "iopub.status.busy": "2026-07-01T09:21:27.313232Z",
+     "iopub.status.idle": "2026-07-01T09:21:27.315621Z",
+     "shell.execute_reply": "2026-07-01T09:21:27.315107Z"
+    }
+   },
    "outputs": [],
    "source": [
     "settings.weight_windows_on = True # Now, turn on the FW-CADIS generated weight windows\n",
@@ -662,7 +879,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "619f2dce",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-01T09:21:27.316561Z",
+     "iopub.status.busy": "2026-07-01T09:21:27.316467Z",
+     "iopub.status.idle": "2026-07-01T09:21:42.055358Z",
+     "shell.execute_reply": "2026-07-01T09:21:42.054360Z"
+    }
+   },
    "outputs": [],
    "source": [
     "run_and_plot(simulation_using_ww_on, \"fw_cadis.png\")"
@@ -671,7 +895,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".neutronicsworkshop_3.12",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -685,7 +909,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.14.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## What

Adds a forward vs adjoint flux comparison to `tasks/task_14_variance_reduction/5_shielded_room_fw_cadis.ipynb`.

The notebook previously plotted only the FW-CADIS weight windows and left a placeholder markdown cell for plotting the flux. This change:

- attaches the mesh flux tally to the random ray model so that both the forward and the adjoint solve record it;
- adds a side by side plot of the forward flux (where neutrons actually go) and the adjoint flux (neutron importance), read from the forward and adjoint statepoints produced by the single FW-CADIS run;
- expands the surrounding text to explain what each flux represents, why the random ray solver runs a forward pass before the adjoint pass, and how the weight windows relate to the adjoint flux.

## Why

Seeing the forward and adjoint flux together is the clearest way to build intuition for FW-CADIS: the forward flux collapses by orders of magnitude into the shield (which is why an analog run starves those regions), while the adjoint flux is highest in exactly those hard to reach regions, and the weight windows follow the adjoint importance.

## Note

The forward solve statepoint is read from `statepoint.forward.<batch>.h5`. This relies on OpenMC writing the forward solve output during an adjoint (FW-CADIS) random ray run, so the notebook needs a recent OpenMC.
