### PR TITLE
Skip hanging weight window notebook in CI book build

### DIFF
--- a/.github/workflows/jupyter_book_build.yaml
+++ b/.github/workflows/jupyter_book_build.yaml
@@ -84,7 +84,13 @@ jobs:
       #   uses: mxschmitt/action-tmate@v3
       - name: Build the book
         run: |
-          jupyter nbconvert --to notebook --execute --inplace tasks/*/*.ipynb
+          # Execute all task notebooks except 4_sphere_iterative_per_batch_ww.ipynb.
+          # That notebook hangs on the CI OpenMC build (the iterative MAGIC weight
+          # windows request excessive particle splitting), which was causing this
+          # job to hit the 6 hour limit and get cancelled before the book deployed.
+          find tasks -mindepth 2 -maxdepth 2 -name '*.ipynb' \
+            ! -path 'tasks/task_14_variance_reduction/4_sphere_iterative_per_batch_ww.ipynb' \
+            -print0 | xargs -0 -r jupyter nbconvert --to notebook --execute --inplace
           pip install jupyter-book==1.0.4
           jupyter-book build .
 


### PR DESCRIPTION
## Problem

The `deploy-book` workflow has been hitting the 6 hour GitHub Actions limit and getting cancelled, so the hosted Jupyter Book has not updated since the 23 June run.

The build step executes every task notebook with `nbconvert`. `tasks/task_14_variance_reduction/4_sphere_iterative_per_batch_ww.ipynb` hangs on the OpenMC build that CI installs: the analog part runs in a few seconds, but the iterative MAGIC weight window part requests excessive particle splitting and effectively stalls. In the last release run it ran for over 2.5 hours without finishing before the job was cancelled at the 6 hour mark, so the deploy step never ran.

The notebook runs in about 7 seconds locally with an older OpenMC build, so this looks like a regression in the rolling `openmc` wheel rather than the notebook logic, but skipping it unblocks the deployment now.

## Change

Execute every task notebook except that one, so the rest execute and the book can deploy.

## Notes

- The notebook is still listed in `_toc.yml`, so its page still appears in the book. It has no committed cell outputs, so the page renders the code and text without plots. If you would rather drop the page entirely, removing its `_toc.yml` line and adding it to `exclude_patterns` in `_config.yml` is a small follow-up.
- A few other notebooks are also slow on the current CI wheel (`task_14/3` ~69 min, `task_11/3` ~56 min, `task_12/3` ~36 min). The build should now finish under 6 hours, but those are worth a look if it stays close to the limit.