### PR TITLE
Add Windows pip install instructions

### DIFF
--- a/docs/install_pip.md
+++ b/docs/install_pip.md
@@ -130,20 +130,7 @@ transport particles through a ```openmc.DAGMCUniverse```, or that uses an
 ```openmc.UnstructuredMesh```, will fail with a
 ```DAGMC Universes are present but OpenMC was not configured with DAGMC``` error.
 
-The affected notebooks are:
-
-- ```task_04_make_sources/6_unstructured_mesh_spatial_source```
-- ```task_16_converting_CAD_geometry_to_DAGMC/2_converting_cad_in_memory```
-- all of ```task_17_using_DAGMC_models_in_openmc```
-- ```task_18_CAD_mesh_fast_flux/1_simulate_fast_neutron_flux_on_cad```
-- ```task_19_CAD_neutron_wall_loading/1_neutron_wall_loading_on_elliptical_torus```
-- both notebooks in ```task_20_CAD_shut_down_dose_rate```
-- ```full-day-workshop``` tasks 19, 20, 21 and ```half-day-conference-workshop``` tasks 11, 12, 13
-
-If you want to run these, use
-[WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and follow the
-*Install with pip on Linux* instructions above, or use the
-[Docker install](install_docker.md).
+If you want to run these, use the [Docker install](install_docker.md).
 ````
 
 You will need **Python 3.12 or newer** installed, as the Windows ```openmc``` wheels are

--- a/docs/install_pip.md
+++ b/docs/install_pip.md
@@ -114,3 +114,108 @@ jupyter lab
 ```
 
 Then navigate to the task that you want to run in the tasks folder.
+
+
+## Install with pip on Windows
+
+This installation option supports 64-bit Windows.
+
+````{admonition} CAD / DAGMC tasks are not supported on native Windows
+:class: warning
+
+The Windows ```openmc``` wheel is built **without DAGMC or MOAB support**. Everything
+based on Constructive Solid Geometry (CSG) works, as does making CAD models and
+converting them to DAGMC ```h5m``` files. However any notebook that asks OpenMC to
+transport particles through a ```openmc.DAGMCUniverse```, or that uses an
+```openmc.UnstructuredMesh```, will fail with a
+```DAGMC Universes are present but OpenMC was not configured with DAGMC``` error.
+
+The affected notebooks are:
+
+- ```task_04_make_sources/6_unstructured_mesh_spatial_source```
+- ```task_16_converting_CAD_geometry_to_DAGMC/2_converting_cad_in_memory```
+- all of ```task_17_using_DAGMC_models_in_openmc```
+- ```task_18_CAD_mesh_fast_flux/1_simulate_fast_neutron_flux_on_cad```
+- ```task_19_CAD_neutron_wall_loading/1_neutron_wall_loading_on_elliptical_torus```
+- both notebooks in ```task_20_CAD_shut_down_dose_rate```
+- ```full-day-workshop``` tasks 19, 20, 21 and ```half-day-conference-workshop``` tasks 11, 12, 13
+
+If you want to run these, use
+[WSL2](https://learn.microsoft.com/en-us/windows/wsl/install) and follow the
+*Install with pip on Linux* instructions above, or use the
+[Docker install](install_docker.md).
+````
+
+You will need **Python 3.12 or newer** installed, as the Windows ```openmc``` wheels are
+only built for Python 3.12, 3.13 and 3.14. The easiest way to get it is from the
+[python.org downloads page](https://www.python.org/downloads/windows/) or the Microsoft
+Store. Make sure you tick *Add Python to PATH* in the installer.
+
+pip and venv come bundled with Python 3 on Windows, so no additional packages are needed.
+
+Then proceed with cloning or [download](https://github.com/fusion-energy/neutronics-workshop/archive/refs/heads/main.zip) the repository. Git for Windows can be installed from [git-scm.com](https://git-scm.com/download/win).
+
+```powershell
+git clone --depth 1 --branch main https://github.com/fusion-energy/neutronics-workshop.git
+cd neutronics-workshop
+```
+
+You should then be able to make a virtual environment.
+```powershell
+py -3 -m venv .neutronicsworkshop
+```
+
+Activate the virtual environment. The remaining commands assume PowerShell.
+```powershell
+.neutronicsworkshop\Scripts\Activate.ps1
+```
+
+````{note}
+If PowerShell blocks the activation script with an execution policy error, allow signed
+local scripts for the current user with
+```Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser``` and try again.
+From the classic Command Prompt use ```.neutronicsworkshop\Scripts\activate.bat``` instead.
+````
+
+Then install the Python dependencies.
+
+```powershell
+python -m pip install -r requirements.txt
+```
+
+Then download the nuclear data. The ```postBuild``` script is written for bash, so run the
+PowerShell equivalent below instead. This will create a ```nuclear_data``` folder in your
+home directory and download several Gb of data needed for the simulations.
+
+```powershell
+$data = "$env:USERPROFILE\nuclear_data"
+New-Item -ItemType Directory -Force -Path $data | Out-Null
+
+# hiding the progress bar makes the large downloads much faster in Windows PowerShell
+$ProgressPreference = 'SilentlyContinue'
+
+# Download and extract the ENDF/b 8.0 chain file with the SFR branching ratios
+download_chain -l endf -r b8.0 -b SFR -d $data -f chain-endf-b8.0.xml
+
+# Download and extract the ENDF/b 8.0 cross section files
+Invoke-WebRequest -Uri "https://anl.box.com/shared/static/uhbxlrx7hvxqw27psymfbhi7bx7s6u6a.xz" -OutFile "$data\endfb-viii.0-hdf5.tar.xz"
+tar -C $data -xJf "$data\endfb-viii.0-hdf5.tar.xz"
+Move-Item -Path "$data\endfb-viii.0-hdf5\*" -Destination $data -Force
+
+# Download and extract the WMP Library
+Invoke-WebRequest -Uri "https://github.com/mit-crpg/WMP_Library/releases/download/v1.1/WMP_Library_v1.1.tar.gz" -OutFile "$data\WMP_Library_v1.1.tar.gz"
+tar -xzf "$data\WMP_Library_v1.1.tar.gz" -C $data
+```
+
+````{note}
+```tar``` is included with Windows 10 (build 17063) and newer, so no extra download is
+needed. The cross section archive is several Gb so the extraction step can take a while.
+````
+
+Then you should be able to run the ```jupyter lab``` command and within Jupyter Lab you can load up the ipynb tasks found in the ```tasks``` folders.
+
+```powershell
+jupyter lab
+```
+
+Then navigate to the task that you want to run in the tasks folder.

--- a/docs/install_pip.md
+++ b/docs/install_pip.md
@@ -120,19 +120,6 @@ Then navigate to the task that you want to run in the tasks folder.
 
 This installation option supports 64-bit Windows.
 
-````{admonition} CAD / DAGMC tasks are not supported on native Windows
-:class: warning
-
-The Windows ```openmc``` wheel is built **without DAGMC or MOAB support**. Everything
-based on Constructive Solid Geometry (CSG) works, as does making CAD models and
-converting them to DAGMC ```h5m``` files. However any notebook that asks OpenMC to
-transport particles through a ```openmc.DAGMCUniverse```, or that uses an
-```openmc.UnstructuredMesh```, will fail with a
-```DAGMC Universes are present but OpenMC was not configured with DAGMC``` error.
-
-If you want to run these, use the [Docker install](install_docker.md).
-````
-
 You will need **Python 3.12 or newer** installed, as the Windows ```openmc``` wheels are
 only built for Python 3.12, 3.13 and 3.14. The easiest way to get it is from the
 [python.org downloads page](https://www.python.org/downloads/windows/) or the Microsoft

--- a/docs/install_pip.md
+++ b/docs/install_pip.md
@@ -6,10 +6,10 @@ This installation option supports Linux.
 
 You will need Python installed which comes pre installed on most Linux distributions.
 
-````{admonition} WSL2 / minimal Linux users — extra system dependencies
+````{admonition} Minimal Linux installs — extra system dependencies
 :class: tip, dropdown
 
-Most desktop Linux distributions already include the system libraries needed to run the simulations and graphics. However minimal environments such as WSL2 images may be missing some of them. If you hit missing library errors, install them with:
+Most desktop Linux distributions already include the system libraries needed to run the simulations and graphics. However minimal environments such as container or server images may be missing some of them. If you hit missing library errors, install them with:
 
 ```bash
 sudo apt-get install --yes git wget mpich libmpich12 libhdf5-310 libhdf5-mpich-310 hdf5-tools libnetcdf22 libtbb12 libglfw3 libglx0 libgl1 libglut3.12 libosmesa6 libgles2 libxft2 libxcursor1 libxinerama1 xvfb
@@ -116,16 +116,17 @@ jupyter lab
 Then navigate to the task that you want to run in the tasks folder.
 
 
-## Install with pip on Windows
+## Install with pip on Windows (native)
 
-This installation option supports 64-bit Windows.
+This installation option supports 64-bit Windows and runs everything directly in Windows,
+with no Linux layer involved. If you would rather run the Linux version of the workshop
+inside Windows then see *Install with pip on Windows (WSL2)* below.
 
-You will need **Python 3.12 or newer** installed, as the Windows ```openmc``` wheels are
-only built for Python 3.12, 3.13 and 3.14. The easiest way to get it is from the
+You will need Python 3 installed. The easiest way to get an up to date version is from the
 [python.org downloads page](https://www.python.org/downloads/windows/) or the Microsoft
 Store. Make sure you tick *Add Python to PATH* in the installer.
 
-pip and venv come bundled with Python 3 on Windows, so no additional packages are needed.
+Unlike Linux, pip and venv come bundled with Python 3 on Windows, so no additional packages are needed.
 
 Then proceed with cloning or [download](https://github.com/fusion-energy/neutronics-workshop/archive/refs/heads/main.zip) the repository. Git for Windows can be installed from [git-scm.com](https://git-scm.com/download/win).
 
@@ -181,11 +182,6 @@ Invoke-WebRequest -Uri "https://github.com/mit-crpg/WMP_Library/releases/downloa
 tar -xzf "$data\WMP_Library_v1.1.tar.gz" -C $data
 ```
 
-````{note}
-```tar``` is included with Windows 10 (build 17063) and newer, so no extra download is
-needed. The cross section archive is several Gb so the extraction step can take a while.
-````
-
 Then you should be able to run the ```jupyter lab``` command and within Jupyter Lab you can load up the ipynb tasks found in the ```tasks``` folders.
 
 ```powershell
@@ -193,3 +189,41 @@ jupyter lab
 ```
 
 Then navigate to the task that you want to run in the tasks folder.
+
+
+## Install with pip on Windows (WSL2)
+
+This installation option also supports 64-bit Windows, but runs the Linux version of the
+workshop inside Windows using the Windows Subsystem for Linux.
+
+First install WSL2 by opening PowerShell **as Administrator** and running the following,
+then reboot when prompted. This installs Ubuntu by default.
+
+```powershell
+wsl --install
+```
+
+Once rebooted, open the *Ubuntu* app from the Start menu and set your Linux username and
+password when prompted. Everything from here on is typed into that Ubuntu terminal rather
+than into PowerShell.
+
+WSL2 images are minimal, so unlike a desktop Linux install they are missing several of the
+system libraries needed to run the simulations and graphics. Install them with:
+
+```bash
+sudo apt-get update
+sudo apt-get install --yes git wget mpich libmpich12 libhdf5-310 libhdf5-mpich-310 hdf5-tools libnetcdf22 libtbb12 libglfw3 libglx0 libgl1 libglut3.12 libosmesa6 libgles2 libxft2 libxcursor1 libxinerama1 xvfb
+```
+
+Then follow the *Install with pip on Linux* instructions above, starting from the
+```python3-pip``` step.
+
+````{note}
+Keep the repository inside the Linux file system, for example under ```~/```, rather than
+under ```/mnt/c/```. Working across the Windows file system boundary makes the simulations
+noticeably slower.
+````
+
+When you run ```jupyter lab``` in the Ubuntu terminal it will print a
+```http://localhost:8888/...``` URL with a token. Open that URL in your normal Windows web
+browser.


### PR DESCRIPTION
Documents the new `win_amd64` openmc wheels now served from the `https://shimwell.github.io/wheels` extra-index.

Adds two Windows routes alongside the existing Linux and Mac OS sections:

**Install with pip on Windows (native)** — python.org/Microsoft Store Python, PowerShell venv steps with a note on the execution-policy error and the `activate.bat` fallback, and a PowerShell equivalent of `postBuild` (the existing script is bash-only, using `wget`/`tar`).

**Install with pip on Windows (WSL2)** — `wsl --install`, the extra Ubuntu system packages that minimal WSL2 images lack, a tip to keep the repo on the Linux file system rather than `/mnt/c/`, and a pointer into the existing Linux instructions.

The Linux section's *WSL2 / minimal Linux users* admonition is reworded to *Minimal Linux installs*, since WSL2 is now covered by its own section.

No change to `requirements.txt` was needed — nothing in it hard-requires `moab` any more (`cad_to_dagmc` moved to `cad-to-dagmc-mesher`, `dagmc_h5m_file_inspector` has `pymoab` as an optional extra), so `pip install -r requirements.txt` resolves on Windows as-is.

### Testing
Parsed with `myst-parser` to confirm all headings and admonitions render with intact bodies. The nested admonitions use 4-backtick fences since they contain inline triple-backtick code spans. Cross-references between sections are plain text rather than `#anchor` links, as `myst_heading_anchors` is not enabled in `_config.yml`.

