### PR TITLE
Stop task_17 notebook 3 overwriting the committed dagmc.h5m

### DIFF
--- a/tasks/task_17_using_DAGMC_models_in_openmc/3_cad_model_simulation_with_hybrid_csg.ipynb
+++ b/tasks/task_17_using_DAGMC_models_in_openmc/3_cad_model_simulation_with_hybrid_csg.ipynb
@@ -104,7 +104,10 @@
     "    cadquery_object=assembly,\n",
     "    material_tags=\"assembly_names\",  # Use names as tags\n",
     ")\n",
-    "dag_mesh.export_dagmc_h5m_file(set_size={'first_wall': 50, 'plasma':50} )"
+    "dag_mesh.export_dagmc_h5m_file(\n",
+    "    set_size={'first_wall': 50, 'plasma':50},\n",
+    "    filename='dagmc-hybrid.h5m'\n",
+    ")"
    ]
   },
   {
@@ -122,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "di.convert_h5m_to_vtkhdf(h5m_filename='dagmc.h5m', vtkhdf_filename= 'dagmc.vtkhdf')"
+    "di.convert_h5m_to_vtkhdf(h5m_filename='dagmc-hybrid.h5m', vtkhdf_filename= 'dagmc-hybrid.vtkhdf')"
    ]
   },
   {
@@ -138,7 +141,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dag_universe = openmc.DAGMCUniverse(filename='dagmc.h5m', auto_geom_ids=True)"
+    "dag_universe = openmc.DAGMCUniverse(filename='dagmc-hybrid.h5m', auto_geom_ids=True)"
    ]
   },
   {


### PR DESCRIPTION
Fixes the intermittent `deploy-book` CI failure, for example [this run](https://github.com/fusion-energy/neutronics-workshop/actions/runs/31101818846/job/92616951932).

### The failure

```
ERROR: Material with name/ID 'first_wall' not found for volume (cell) 1
RuntimeError: Material with name/ID 'first_wall' not found for volume (cell) 1
```

raised by `tasks/task_17_using_DAGMC_models_in_openmc/1_cad_model_simulation_minimal.ipynb`.

### Cause

`CadToDagmc.export_dagmc_h5m_file` has `filename: str = "dagmc.h5m"`. In notebook 3 the first export was called without a filename:

```python
dag_mesh.export_dagmc_h5m_file(set_size={'first_wall': 50, 'plasma':50})
```

nbconvert executes each notebook with its own directory as the working directory, so this wrote over the **committed** `tasks/task_17_using_DAGMC_models_in_openmc/dagmc.h5m`. That committed file is tagged `mat:mat1` and is the input notebook 1 relies on; notebook 3 replaced it with a torus tagged `first_wall` / `plasma`.

Notebook 1 then loaded the clobbered file and aborted. Because it depends on the order nbconvert happens to pick, the job failed only sometimes.

### Fix

Export to `dagmc-hybrid.h5m` and read that back in the two following cells. This matches what notebook 2 (`dagmc_quarter.h5m`) and the implicit-complement export later in notebook 3 (`dagmc-with-imp-comp-mat.h5m`) already do.

### Checks

- Audited every `export_dagmc_h5m_file` call across `tasks/`; after this change all of them pass an explicit filename. The only other bare-looking call, in `task_19_CAD_neutron_wall_loading`, passes `"dagmc.h5m"` positionally into a directory with no committed h5m, so it is fine.
- `*.h5m` and `*.vtkhdf` are already in `.gitignore`, so the new generated file will not be committed.
- The committed `dagmc.h5m` is unchanged and still tagged `mat:mat1`.
