### PR TITLE
Deploy the book to GitHub Pages on release as well as push

### DIFF
--- a/.github/workflows/jupyter_book_build.yaml
+++ b/.github/workflows/jupyter_book_build.yaml
@@ -113,8 +113,10 @@ jobs:
           path: "_build/html"
           name: github-pages
 
-      # Deploy the book's HTML to GitHub Pages
+      # Deploy the book's HTML to GitHub Pages.
+      # Releases deploy as well as pushes to main, otherwise a release spends
+      # hours executing every notebook and then skips the deployment.
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Releases never published the book to GitHub Pages.

### Cause

The deploy step was gated on:

```yaml
if: github.event_name == 'push' && github.ref == 'refs/heads/main'
```

A `release` event cannot satisfy that, even though `release: types: [created]` is one of the workflow's triggers. So a release ran the full notebook execution and then skipped the deployment. The step list from the `v0.11.2` release run ([run 29359886108](https://github.com/fusion-energy/neutronics-workshop/actions/runs/29359886108)) shows it:

```
9.  Build the book: failure
10. Upload artifact: skipped
11. Deploy to GitHub Pages: skipped
```

That run also spent 2h41m before failing, so the wasted compute was real — but the deployment would have been skipped regardless of whether the build had passed.

### Fix

```yaml
if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
```

Notebook execution is deliberately left as-is, so a release still executes the notebooks before building. This matters because all 130 task notebooks are committed with their outputs stripped and `_config.yml` sets `execute_notebooks: off` — skipping execution would publish a book of code cells with no plots or results.

### Notes

- Full runs currently take roughly 2h41m to 3h39m against the 6 hour job limit. This PR does not change that; parallelising notebook execution is a separate piece of work.
- Pushing to main and creating a release in quick succession will now queue two Pages deployments. GitHub serialises deployments per environment, so they will not clash, but a `concurrency` group could be added later if the double build becomes annoying.
